### PR TITLE
扩展基于几何签名的子拓扑匹配机制

### DIFF
--- a/src/simplecadapi/expr.py
+++ b/src/simplecadapi/expr.py
@@ -387,6 +387,7 @@ def _is_discrete_param_name(key: str) -> bool:
         "profile_count",
         "count",
         "output_count",
+        "selected_subshapes",
     }
 
 

--- a/src/simplecadapi/freecad_translator.py
+++ b/src/simplecadapi/freecad_translator.py
@@ -2045,6 +2045,73 @@ def _match_subshape_indices(obj, params, kind, role=None, allow_duplicate_matche
     return result
 
 
+def _selected_subshape_features(obj, params, kind, role, name_prefix, allow_duplicate_matches=False):
+    indices = _match_subshape_indices(
+        obj,
+        params,
+        kind,
+        role,
+        allow_duplicate_matches=allow_duplicate_matches,
+    )
+    if indices is None:
+        return None
+    shape = getattr(obj, 'Shape', obj)
+    candidates = list(shape.Edges if str(kind).lower() == 'edge' else shape.Faces)
+    features = []
+    for order, idx in enumerate(indices):
+        feature = doc.addObject('Part::Feature', f'{name_prefix}_{order}')
+        feature.Shape = candidates[int(idx) - 1]
+        _set_visibility(feature, False)
+        features.append(feature)
+    return features
+
+
+def _selected_edge_wire_feature(obj, selection_payload, name):
+    wrapper = {'selected_subshapes': selection_payload}
+    edge_features = _selected_subshape_features(obj, wrapper, 'edge', None, f'{name}_edge')
+    if not edge_features:
+        return None
+    feature = doc.addObject('Part::Feature', name)
+    feature.Shape = Part.Wire([edge.Shape for edge in edge_features])
+    _set_visibility(feature, False)
+    return feature
+
+
+def _selected_edge_wire_feature_from_sources(selection_payload, name):
+    items = selection_payload.get('items') if isinstance(selection_payload, dict) else None
+    if not isinstance(items, list):
+        return None
+    edge_features = []
+    for order, item in enumerate(items):
+        source = item.get('source') if isinstance(item, dict) else None
+        source_node = source.get('node_id') if isinstance(source, dict) else None
+        if not source_node:
+            raise RuntimeError('selected edge item is missing source node_id')
+        source_obj = GRAPH_NODES[str(source_node)]
+        wrapper = {'selected_subshapes': {'items': [item]}}
+        matched = _selected_subshape_features(source_obj, wrapper, 'edge', None, f'{name}_edge_{order}')
+        if not matched:
+            raise RuntimeError('selected edge item did not match its source shape')
+        edge_features.extend(matched)
+    feature = doc.addObject('Part::Feature', name)
+    feature.Shape = Part.Wire([edge.Shape for edge in edge_features])
+    _set_visibility(feature, False)
+    return feature
+
+
+def _selected_source_feature(obj, params, edge_role, face_role, name):
+    selected_kind = str(params.get('selected_source_kind', '')).lower()
+    if selected_kind == 'wire':
+        return _selected_edge_wire_feature(obj, params.get('selected_subshapes'), name)
+    face_features = _selected_subshape_features(obj, params, 'face', face_role, name)
+    if face_features:
+        return face_features[0]
+    edge_features = _selected_subshape_features(obj, params, 'edge', edge_role, name)
+    if edge_features:
+        return edge_features[0]
+    return None
+
+
 def _legacy_edge_indices(params):
     print('SimpleCAD warning: using legacy selected_edge_indices fallback; new graphs should use selected_subshapes geometry signatures.')
     return [int(idx) + 1 for idx in params.get('selected_edge_indices', [])]
@@ -2256,6 +2323,14 @@ def _joint_reference_from_anchor(anchor):
 
         if node.op == "make_wire_from_edges_rwire":
             input_nodes = [graph.get_node(node_id) for node_id in inputs]
+            if node.params.get("selected_subshapes"):
+                lines = [
+                    f"{var_name}_wire_feature = _selected_edge_wire_feature_from_sources({rp}.get('selected_subshapes'), {_json_ascii(_safe_name(object_name, prefix='wire'))})",
+                    f"if {var_name}_wire_feature is None:",
+                    f"    raise RuntimeError('make_wire_from_edges_rwire expected selected_subshapes geometry signatures for wire_edge')",
+                    f"{var_name} = _register_graph_object({var_name}_wire_feature, node_id={_json_ascii(node.node_id)}, op={_json_ascii(node.op)}, params={rp}, inputs={var_name}_inputs, tags={tags_literal}, context={context_literal}, output_count={node.output_count}, param_exprs={param_exprs_literal}, semantic_delta={semantic_delta_literal}, topo_delta={topo_delta_literal})",
+                ]
+                return lines
             if len(inputs) == 1:
                 single = input_nodes[0]
                 if single is not None and single.op == "make_helix_redge":
@@ -2501,6 +2576,15 @@ def _joint_reference_from_anchor(anchor):
             return lines
 
         if node.op == "make_face_from_wire_rface":
+            if node.params.get("selected_subshapes") and len(inputs) == 1:
+                lines = [
+                    f"{var_name}_wire_feature = _selected_edge_wire_feature(GRAPH_NODES[{_json_ascii(inputs[0])}], {rp}.get('selected_subshapes'), {_json_ascii(_safe_name(f'{object_name}_wire', prefix='wire'))})",
+                    f"if {var_name}_wire_feature is None:",
+                    f"    raise RuntimeError('make_face_from_wire_rface expected selected_subshapes geometry signatures for face_boundary_edge')",
+                    f"{var_name} = _build_face_from_source({var_name}_wire_feature, {_json_ascii(object_name)})",
+                ]
+                lines.extend(finish())
+                return lines
             input_node = graph.get_node(inputs[0]) if inputs else None
             if input_node is not None and input_node.op == "make_wire_from_edges_rwire":
                 return finish_alias(inputs[0])
@@ -2573,6 +2657,24 @@ def _joint_reference_from_anchor(anchor):
 
         if node.op == "make_extrude_rsolid" and len(inputs) == 1:
             base_node = graph.get_node(inputs[0])
+            if node.params.get("selected_subshapes"):
+                lines = [
+                    f"{var_name}_profile_features = _selected_subshape_features(GRAPH_NODES[{_json_ascii(inputs[0])}], {rp}, 'face', 'extrude_profile_face', {_json_ascii(_safe_name(f'{object_name}_profile', prefix='profile'))})",
+                    f"if not {var_name}_profile_features:",
+                    f"    raise RuntimeError('make_extrude_rsolid expected selected_subshapes geometry signatures for extrude_profile_face')",
+                    f"{var_name} = doc.addObject('Part::Extrusion', {_json_ascii(object_name)})",
+                    f"{var_name}.Base = {var_name}_profile_features[0]",
+                    f"{var_name}.DirMode = 'Custom'",
+                    f"{var_name}.Dir = _vec(_resolve_vec3_param({rp}, {re}, 'direction'))",
+                    f"{var_name}.LengthFwd = float(_resolve_param_value({rp}, {re}, 'distance'))",
+                    f"{var_name}.LengthRev = 0.0",
+                    f"{var_name}.Solid = True",
+                ]
+                lines.append(
+                    f"_apply_op_expression_bindings({var_name}, {_json_ascii(node.op)}, {re})"
+                )
+                lines.extend(finish())
+                return lines
             if base_node is not None and base_node.op in {
                 "make_face_from_wire_rface",
                 "make_wire_from_edges_rwire",
@@ -2601,6 +2703,23 @@ def _joint_reference_from_anchor(anchor):
 
         if node.op == "make_revolve_rsolid" and len(inputs) == 1:
             base_node = graph.get_node(inputs[0])
+            if node.params.get("selected_subshapes"):
+                lines = [
+                    f"{var_name}_profile_features = _selected_subshape_features(GRAPH_NODES[{_json_ascii(inputs[0])}], {rp}, 'face', 'revolve_profile_face', {_json_ascii(_safe_name(f'{object_name}_profile', prefix='profile'))})",
+                    f"if not {var_name}_profile_features:",
+                    f"    raise RuntimeError('make_revolve_rsolid expected selected_subshapes geometry signatures for revolve_profile_face')",
+                    f"{var_name} = doc.addObject('Part::Revolution', {_json_ascii(object_name)})",
+                    f"{var_name}.Source = {var_name}_profile_features[0]",
+                    f"{var_name}.Axis = _vec(_resolve_vec3_param({rp}, {re}, 'axis') if 'axis' in {rp} else (0.0, 0.0, 1.0))",
+                    f"{var_name}.Base = _vec(_resolve_vec3_param({rp}, {re}, 'origin') if 'origin' in {rp} else (0.0, 0.0, 0.0))",
+                    f"{var_name}.Angle = float(_resolve_param_value({rp}, {re}, 'angle') if 'angle' in {rp} else 360.0)",
+                    f"{var_name}.Solid = True",
+                ]
+                lines.append(
+                    f"_apply_op_expression_bindings({var_name}, {_json_ascii(node.op)}, {re})"
+                )
+                lines.extend(finish())
+                return lines
             if base_node is not None and base_node.op == "make_face_from_wire_rface":
                 lines = [
                     f"{var_name} = doc.addObject('Part::Revolution', {_json_ascii(object_name)})",
@@ -2617,12 +2736,27 @@ def _joint_reference_from_anchor(anchor):
                 return lines
 
         if node.op == "make_loft_rsolid" and len(inputs) >= 2:
-            lines = [
-                f"{var_name} = doc.addObject('Part::Loft', {_json_ascii(object_name)})",
-                f"{var_name}.Sections = [GRAPH_NODES[node_id] for node_id in {var_name}_inputs]",
-                f"{var_name}.Solid = True",
-                f"{var_name}.Ruled = bool(_resolve_param_value({rp}, {re}, 'ruled') if 'ruled' in {rp} else False)",
-            ]
+            if node.params.get("selected_profile_subshapes"):
+                lines = [
+                    f"{var_name}_sections = []",
+                    f"for _idx, _selection_payload in enumerate({rp}.get('selected_profile_subshapes', [])):",
+                    f"    _owner = GRAPH_NODES[{var_name}_inputs[_idx]]",
+                    f"    _wire_feature = _selected_edge_wire_feature(_owner, _selection_payload, f'{_safe_name(object_name, prefix='loft_profile')}_{{_idx}}')",
+                    f"    if _wire_feature is None:",
+                    f"        raise RuntimeError('make_loft_rsolid expected selected_profile_subshapes geometry signatures')",
+                    f"    {var_name}_sections.append(_wire_feature)",
+                    f"{var_name} = doc.addObject('Part::Loft', {_json_ascii(object_name)})",
+                    f"{var_name}.Sections = {var_name}_sections",
+                    f"{var_name}.Solid = True",
+                    f"{var_name}.Ruled = bool(_resolve_param_value({rp}, {re}, 'ruled') if 'ruled' in {rp} else False)",
+                ]
+            else:
+                lines = [
+                    f"{var_name} = doc.addObject('Part::Loft', {_json_ascii(object_name)})",
+                    f"{var_name}.Sections = [GRAPH_NODES[node_id] for node_id in {var_name}_inputs]",
+                    f"{var_name}.Solid = True",
+                    f"{var_name}.Ruled = bool(_resolve_param_value({rp}, {re}, 'ruled') if 'ruled' in {rp} else False)",
+                ]
             lines.append(
                 f"_apply_op_expression_bindings({var_name}, {_json_ascii(node.op)}, {re})"
             )
@@ -2633,6 +2767,13 @@ def _joint_reference_from_anchor(anchor):
             lines = [
                 f"{var_name}_profile_obj = GRAPH_NODES[{_json_ascii(inputs[0])}]",
                 f"{var_name}_profile_face_indices = _match_subshape_indices({var_name}_profile_obj, {rp}, 'face', 'sweep_profile_face')",
+                f"{var_name}_path_obj = GRAPH_NODES[{_json_ascii(inputs[1])}]",
+                f"if isinstance({rp}.get('selected_path_subshapes'), dict):",
+                f"    {var_name}_path_feature = _selected_edge_wire_feature({var_name}_path_obj, {rp}.get('selected_path_subshapes'), {_json_ascii(_safe_name(f'{object_name}_path', prefix='path'))})",
+                f"    if {var_name}_path_feature is None:",
+                f"        raise RuntimeError('make_sweep_rsolid expected selected_path_subshapes geometry signatures')",
+                f"else:",
+                f"    {var_name}_path_feature = {var_name}_path_obj",
                 f"{var_name} = doc.addObject('Part::Sweep', {_json_ascii(object_name)})",
                 f"if {var_name}_profile_face_indices is None:",
                 f"    {var_name}.Sections = [{var_name}_profile_obj]",
@@ -2642,7 +2783,7 @@ def _joint_reference_from_anchor(anchor):
                 f"    {var_name}_profile_feature.Shape = {var_name}_profile_shape",
                 f"    _set_visibility({var_name}_profile_feature, False)",
                 f"    {var_name}.Sections = [{var_name}_profile_feature]",
-                f"{var_name}.Spine = GRAPH_NODES[{_json_ascii(inputs[1])}]",
+                f"{var_name}.Spine = {var_name}_path_feature",
                 f"{var_name}.Solid = True",
                 f"{var_name}.Frenet = bool(_resolve_param_value({rp}, {re}, 'is_frenet') if 'is_frenet' in {rp} else False)",
             ]
@@ -2756,8 +2897,13 @@ def _joint_reference_from_anchor(anchor):
 
         if node.op == "make_mirror_rshape" and len(inputs) == 1:
             lines = [
+                f"{var_name}_source = GRAPH_NODES[{_json_ascii(inputs[0])}]",
+                f"if {rp}.get('selected_subshapes'):",
+                f"    {var_name}_source = _selected_source_feature({var_name}_source, {rp}, 'mirror_source_edge', 'mirror_source_face', {_json_ascii(_safe_name(f'{object_name}_source', prefix='source'))})",
+                f"    if {var_name}_source is None:",
+                f"        raise RuntimeError('make_mirror_rshape expected selected_subshapes geometry signatures for selected source shape')",
                 f"{var_name} = doc.addObject('Part::Mirroring', {_json_ascii(object_name)})",
-                f"{var_name}.Source = GRAPH_NODES[{_json_ascii(inputs[0])}]",
+                f"{var_name}.Source = {var_name}_source",
                 f"{var_name}.Base = _vec(_resolve_vec3_param({rp}, {re}, 'plane_origin') if 'plane_origin' in {rp} else (0.0, 0.0, 0.0))",
                 f"{var_name}.Normal = _vec(_resolve_vec3_param({rp}, {re}, 'plane_normal') if 'plane_normal' in {rp} else (0.0, 0.0, 1.0))",
             ]
@@ -2771,13 +2917,21 @@ def _joint_reference_from_anchor(anchor):
             vector = node.params.get("vector")
             if isinstance(vector, (list, tuple)) and len(vector) == 3:
                 try:
-                    if all(abs(float(v)) <= 1e-12 for v in vector):
+                    if (
+                        all(abs(float(v)) <= 1e-12 for v in vector)
+                        and not node.params.get("selected_subshapes")
+                    ):
                         return finish_alias(inputs[0])
                 except Exception:
                     pass
             lines = [
+                f"{var_name}_linked = GRAPH_NODES[{_json_ascii(inputs[0])}]",
+                f"if {rp}.get('selected_subshapes'):",
+                f"    {var_name}_linked = _selected_source_feature({var_name}_linked, {rp}, 'translate_source_edge', 'translate_source_face', {_json_ascii(_safe_name(f'{object_name}_source', prefix='source'))})",
+                f"    if {var_name}_linked is None:",
+                f"        raise RuntimeError('make_translate_rshape expected selected_subshapes geometry signatures for selected source shape')",
                 f"{var_name} = doc.addObject('App::Link', {_json_ascii(object_name)})",
-                f"{var_name}.LinkedObject = GRAPH_NODES[{_json_ascii(inputs[0])}]",
+                f"{var_name}.LinkedObject = {var_name}_linked",
                 f"{var_name}.Placement = App.Placement(_vec(_resolve_vec3_param({rp}, {re}, 'vector')), App.Rotation())",
             ]
             lines.append(
@@ -2788,8 +2942,13 @@ def _joint_reference_from_anchor(anchor):
 
         if node.op == "make_rotate_rshape" and len(inputs) == 1:
             lines = [
+                f"{var_name}_linked = GRAPH_NODES[{_json_ascii(inputs[0])}]",
+                f"if {rp}.get('selected_subshapes'):",
+                f"    {var_name}_linked = _selected_source_feature({var_name}_linked, {rp}, 'rotate_source_edge', 'rotate_source_face', {_json_ascii(_safe_name(f'{object_name}_source', prefix='source'))})",
+                f"    if {var_name}_linked is None:",
+                f"        raise RuntimeError('make_rotate_rshape expected selected_subshapes geometry signatures for selected source shape')",
                 f"{var_name} = doc.addObject('App::Link', {_json_ascii(object_name)})",
-                f"{var_name}.LinkedObject = GRAPH_NODES[{_json_ascii(inputs[0])}]",
+                f"{var_name}.LinkedObject = {var_name}_linked",
                 f"{var_name}.Placement = App.Placement(_vec(_resolve_vec3_param({rp}, {re}, 'origin') if 'origin' in {rp} else (0.0, 0.0, 0.0)), App.Rotation(_vec(_resolve_vec3_param({rp}, {re}, 'axis') if 'axis' in {rp} else (0.0, 0.0, 1.0)), float(_resolve_param_value({rp}, {re}, 'angle'))))",
             ]
             lines.append(

--- a/src/simplecadapi/freecad_translator.py
+++ b/src/simplecadapi/freecad_translator.py
@@ -1656,6 +1656,405 @@ def _resolve_vec3_param(params, param_exprs, key):
     )
 
 
+def _tuple3(value):
+    if value is None:
+        return None
+    if hasattr(value, 'x') and hasattr(value, 'y') and hasattr(value, 'z'):
+        return (float(value.x), float(value.y), float(value.z))
+    if hasattr(value, 'X') and hasattr(value, 'Y') and hasattr(value, 'Z'):
+        return (float(value.X()), float(value.Y()), float(value.Z()))
+    if isinstance(value, (list, tuple)) and len(value) == 3:
+        return (float(value[0]), float(value[1]), float(value[2]))
+    return None
+
+
+def _point_payload(value):
+    vec = _tuple3(value)
+    if vec is None:
+        return None
+    return [float(vec[0]), float(vec[1]), float(vec[2])]
+
+
+def _normalized_tuple(value):
+    vec = _tuple3(value)
+    if vec is None:
+        return None
+    length = math.sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2])
+    if length <= 1e-12:
+        return None
+    return (vec[0] / length, vec[1] / length, vec[2] / length)
+
+
+def _shape_bbox_payload(shape):
+    bbox = shape.BoundBox
+    xmin, ymin, zmin = float(bbox.XMin), float(bbox.YMin), float(bbox.ZMin)
+    xmax, ymax, zmax = float(bbox.XMax), float(bbox.YMax), float(bbox.ZMax)
+    return {
+        'min': [xmin, ymin, zmin],
+        'max': [xmax, ymax, zmax],
+        'size': [xmax - xmin, ymax - ymin, zmax - zmin],
+    }
+
+
+def _curve_type(edge):
+    try:
+        curve = edge.Curve
+        name = type(curve).__name__.lower()
+        if 'line' in name:
+            return 'line'
+        if 'circle' in name:
+            first = float(getattr(edge, 'FirstParameter', 0.0))
+            last = float(getattr(edge, 'LastParameter', 0.0))
+            return 'circle' if abs(abs(last - first) - 2.0 * math.pi) <= 1e-5 else 'arc'
+        if 'bspline' in name:
+            return 'bspline'
+        if 'bezier' in name:
+            return 'bezier'
+        return name
+    except Exception:
+        return 'unknown'
+
+
+def _surface_type(face):
+    try:
+        surface = face.Surface
+        name = type(surface).__name__.lower()
+        if 'plane' in name:
+            return 'plane'
+        if 'cylinder' in name:
+            return 'cylinder'
+        if 'cone' in name:
+            return 'cone'
+        if 'sphere' in name:
+            return 'sphere'
+        if 'torus' in name:
+            return 'torus'
+        if 'bspline' in name:
+            return 'bspline'
+        if 'bezier' in name:
+            return 'bezier'
+        return name
+    except Exception:
+        return 'unknown'
+
+
+def _edge_endpoints(edge):
+    try:
+        verts = list(edge.Vertexes)
+        if len(verts) >= 2:
+            return [_point_payload(verts[0].Point), _point_payload(verts[-1].Point)]
+    except Exception:
+        pass
+    try:
+        return [
+            _point_payload(edge.valueAt(float(edge.FirstParameter))),
+            _point_payload(edge.valueAt(float(edge.LastParameter))),
+        ]
+    except Exception:
+        return None
+
+
+def _edge_midpoint(edge):
+    try:
+        first = float(edge.FirstParameter)
+        last = float(edge.LastParameter)
+        return _point_payload(edge.valueAt(0.5 * (first + last)))
+    except Exception:
+        try:
+            return _point_payload(edge.CenterOfMass)
+        except Exception:
+            return None
+
+
+def _edge_tangent(edge):
+    try:
+        first = float(edge.FirstParameter)
+        last = float(edge.LastParameter)
+        _, tangent = edge.tangentAt(0.5 * (first + last))
+        return list(_normalized_tuple(tangent) or ())
+    except Exception:
+        endpoints = _edge_endpoints(edge)
+        if endpoints and len(endpoints) == 2 and endpoints[0] is not None and endpoints[1] is not None:
+            start, end = endpoints
+            return list(_normalized_tuple((end[0] - start[0], end[1] - start[1], end[2] - start[2])) or ())
+    return None
+
+
+def _edge_radius(edge):
+    try:
+        curve = edge.Curve
+        radius = getattr(curve, 'Radius', None)
+        if radius is not None:
+            return float(radius)
+    except Exception:
+        pass
+    return None
+
+
+def _face_radius(face):
+    try:
+        surface = face.Surface
+        radius = getattr(surface, 'Radius', None)
+        if radius is not None:
+            return float(radius)
+        major = getattr(surface, 'MajorRadius', None)
+        if major is not None:
+            return float(major)
+    except Exception:
+        pass
+    return None
+
+
+def _geometry_signature(subshape, kind):
+    kind = str(kind).lower()
+    if kind == 'edge':
+        signature = {
+            'kind': 'edge',
+            'curve_type': _curve_type(subshape),
+            'length': float(subshape.Length),
+            'bbox': _shape_bbox_payload(subshape),
+            'tags': [],
+        }
+        center = _point_payload(getattr(subshape, 'CenterOfMass', None))
+        midpoint = _edge_midpoint(subshape)
+        tangent = _edge_tangent(subshape)
+        radius = _edge_radius(subshape)
+        endpoints = _edge_endpoints(subshape)
+        if center is not None:
+            signature['center'] = center
+        if midpoint is not None:
+            signature['midpoint'] = midpoint
+        if tangent:
+            signature['tangent'] = tangent
+            signature['direction'] = tangent
+        if radius is not None:
+            signature['radius'] = radius
+        if endpoints is not None:
+            signature['endpoints'] = endpoints
+        return signature
+    if kind == 'face':
+        signature = {
+            'kind': 'face',
+            'surface_type': _surface_type(subshape),
+            'area': float(subshape.Area),
+            'bbox': _shape_bbox_payload(subshape),
+            'tags': [],
+        }
+        center = _point_payload(getattr(subshape, 'CenterOfMass', None))
+        if center is not None:
+            signature['center'] = center
+        try:
+            u0, u1, v0, v1 = subshape.ParameterRange
+            normal = subshape.normalAt(0.5 * (float(u0) + float(u1)), 0.5 * (float(v0) + float(v1)))
+            norm = _normalized_tuple(normal)
+            if norm is not None:
+                signature['normal'] = list(norm)
+        except Exception:
+            pass
+        radius = _face_radius(subshape)
+        if radius is not None:
+            signature['radius'] = radius
+        return signature
+    raise RuntimeError(f'Unsupported selected subshape kind {kind!r}')
+
+
+def _bbox_scale(signature):
+    bbox = signature.get('bbox') if isinstance(signature, dict) else None
+    if isinstance(bbox, dict):
+        size = bbox.get('size')
+        if isinstance(size, (list, tuple)) and len(size) == 3:
+            try:
+                return max(math.sqrt(sum(float(v) * float(v) for v in size)), 1e-5)
+            except Exception:
+                pass
+    for key in ('length', 'radius'):
+        if isinstance(signature, dict) and key in signature:
+            try:
+                return max(abs(float(signature[key])), 1e-5)
+            except Exception:
+                pass
+    if isinstance(signature, dict) and 'area' in signature:
+        try:
+            return max(math.sqrt(abs(float(signature['area']))), 1e-5)
+        except Exception:
+            pass
+    return 1.0
+
+
+def _point_tol(target, candidate):
+    return max(1e-5, _bbox_scale(target) * 1e-6, _bbox_scale(candidate) * 1e-6)
+
+
+def _scalar_close(a, b):
+    try:
+        af = float(a)
+        bf = float(b)
+    except Exception:
+        return False
+    return abs(af - bf) <= max(1e-7, abs(af) * 1e-6, abs(bf) * 1e-6)
+
+
+def _distance3(a, b):
+    av = _tuple3(a)
+    bv = _tuple3(b)
+    if av is None or bv is None:
+        return None
+    return math.sqrt((av[0] - bv[0]) ** 2 + (av[1] - bv[1]) ** 2 + (av[2] - bv[2]) ** 2)
+
+
+def _vec_close(a, b, tol):
+    dist = _distance3(a, b)
+    return dist is not None and dist <= tol
+
+
+def _direction_close(a, b):
+    av = _normalized_tuple(a)
+    bv = _normalized_tuple(b)
+    if av is None or bv is None:
+        return False
+    return abs(av[0] * bv[0] + av[1] * bv[1] + av[2] * bv[2]) >= 1.0 - 1e-5
+
+
+def _bbox_close(a, b, tol):
+    if not isinstance(a, dict) or not isinstance(b, dict):
+        return False
+    return _vec_close(a.get('min'), b.get('min'), tol) and _vec_close(a.get('max'), b.get('max'), tol)
+
+
+def _endpoints_close(a, b, tol):
+    if not (
+        isinstance(a, (list, tuple)) and isinstance(b, (list, tuple)) and
+        len(a) == 2 and len(b) == 2
+    ):
+        return False
+    direct = _vec_close(a[0], b[0], tol) and _vec_close(a[1], b[1], tol)
+    reverse = _vec_close(a[0], b[1], tol) and _vec_close(a[1], b[0], tol)
+    return direct or reverse
+
+
+def _signatures_match(candidate, target, kind):
+    if not isinstance(candidate, dict) or not isinstance(target, dict):
+        return False
+    kind = str(kind).lower()
+    if str(candidate.get('kind', kind)).lower() != kind or str(target.get('kind', kind)).lower() != kind:
+        return False
+    compared = 0
+    tol = _point_tol(target, candidate)
+    type_key = 'curve_type' if kind == 'edge' else 'surface_type'
+    if target.get(type_key) and candidate.get(type_key):
+        compared += 1
+        if str(target[type_key]).lower() != str(candidate[type_key]).lower():
+            return False
+    for key in ('length', 'area', 'radius'):
+        if key in target and key in candidate:
+            compared += 1
+            if not _scalar_close(target[key], candidate[key]):
+                return False
+    for key in ('center', 'midpoint'):
+        if key in target and key in candidate:
+            compared += 1
+            if not _vec_close(target[key], candidate[key], tol):
+                return False
+    for key in ('normal', 'tangent', 'direction'):
+        if key in target and key in candidate:
+            compared += 1
+            if not _direction_close(target[key], candidate[key]):
+                return False
+    if 'bbox' in target and 'bbox' in candidate:
+        compared += 1
+        if not _bbox_close(target['bbox'], candidate['bbox'], tol):
+            return False
+    if 'endpoints' in target and 'endpoints' in candidate:
+        compared += 1
+        if not _endpoints_close(target['endpoints'], candidate['endpoints'], tol):
+            return False
+    return compared > 0
+
+
+def _signature_summary(signature):
+    if not isinstance(signature, dict):
+        return {}
+    keys = ('kind', 'surface_type', 'curve_type', 'center', 'midpoint', 'normal', 'length', 'area', 'radius', 'bbox')
+    return {key: signature[key] for key in keys if key in signature}
+
+
+def _selected_subshape_items(params, kind, role=None):
+    selected = params.get('selected_subshapes') if isinstance(params, dict) else None
+    if not isinstance(selected, dict) or not isinstance(selected.get('items'), list):
+        return []
+    result = []
+    for item in selected.get('items', []):
+        if not isinstance(item, dict):
+            continue
+        if str(item.get('kind', '')).lower() != str(kind).lower():
+            continue
+        if role is not None and str(item.get('role', '')).lower() != str(role).lower():
+            continue
+        result.append(item)
+    if not result and role is not None:
+        return _selected_subshape_items(params, kind)
+    return result
+
+
+def _selection_match_error(reason, item, kind, candidate_count, match_count):
+    signature = item.get('geometry_signature') if isinstance(item, dict) else {}
+    source = item.get('source') if isinstance(item, dict) and isinstance(item.get('source'), dict) else {}
+    selected_id = item.get('item_id', '<unknown>') if isinstance(item, dict) else '<unknown>'
+    method = item.get('original_selection_method') if isinstance(item, dict) else None
+    return RuntimeError(
+        'selected_subshape geometry match failed: '
+        f'{reason}; source node={source.get("node_id")}; '
+        f'selected_subshape id={selected_id}; kind={kind}; '
+        f'original selection method={method}; '
+        f'signature={_signature_summary(signature)}; '
+        f'matches={match_count}; candidates={candidate_count}'
+    )
+
+
+def _match_subshape_indices(obj, params, kind, role=None, allow_duplicate_matches=False):
+    items = _selected_subshape_items(params, kind, role)
+    if not items:
+        return None
+    shape = getattr(obj, 'Shape', obj)
+    try:
+        if shape is None or shape.isNull():
+            doc.recompute()
+            shape = getattr(obj, 'Shape', obj)
+    except Exception:
+        pass
+    if shape is None or shape.isNull():
+        raise RuntimeError(f'Source object {getattr(obj, "Name", "<unknown>")} has no valid shape')
+    candidates = list(shape.Edges if str(kind).lower() == 'edge' else shape.Faces)
+    candidate_signatures = [_geometry_signature(candidate, kind) for candidate in candidates]
+    used = set()
+    result = []
+    for item in items:
+        target = item.get('geometry_signature') if isinstance(item.get('geometry_signature'), dict) else None
+        if target is None:
+            raise _selection_match_error('missing geometry_signature', item, kind, len(candidates), 0)
+        matches = [idx for idx, candidate in enumerate(candidate_signatures) if _signatures_match(candidate, target, kind)]
+        if not matches:
+            raise _selection_match_error('no candidate matched the stored geometry signature', item, kind, len(candidates), 0)
+        if len(matches) > 1:
+            raise _selection_match_error('ambiguous geometry signature matched multiple candidates', item, kind, len(candidates), len(matches))
+        idx = matches[0]
+        if idx in used and not allow_duplicate_matches:
+            raise _selection_match_error('duplicate selection items matched the same candidate', item, kind, len(candidates), 1)
+        used.add(idx)
+        result.append(idx + 1)
+    return result
+
+
+def _legacy_edge_indices(params):
+    print('SimpleCAD warning: using legacy selected_edge_indices fallback; new graphs should use selected_subshapes geometry signatures.')
+    return [int(idx) + 1 for idx in params.get('selected_edge_indices', [])]
+
+
+def _legacy_face_names(params):
+    print('SimpleCAD warning: using legacy selected_face_indices fallback; new graphs should use selected_subshapes geometry signatures.')
+    return ['Face' + str(int(i) + 1) for i in params.get('selected_face_indices', [])]
+
+
 def _make_native_assembly(name):
     if Assembly is None:
         return None
@@ -2232,8 +2631,17 @@ def _joint_reference_from_anchor(anchor):
 
         if node.op == "make_sweep_rsolid" and len(inputs) == 2:
             lines = [
+                f"{var_name}_profile_obj = GRAPH_NODES[{_json_ascii(inputs[0])}]",
+                f"{var_name}_profile_face_indices = _match_subshape_indices({var_name}_profile_obj, {rp}, 'face', 'sweep_profile_face')",
                 f"{var_name} = doc.addObject('Part::Sweep', {_json_ascii(object_name)})",
-                f"{var_name}.Sections = [GRAPH_NODES[{_json_ascii(inputs[0])}]]",
+                f"if {var_name}_profile_face_indices is None:",
+                f"    {var_name}.Sections = [{var_name}_profile_obj]",
+                f"else:",
+                f"    {var_name}_profile_shape = {var_name}_profile_obj.Shape.Faces[int({var_name}_profile_face_indices[0]) - 1]",
+                f"    {var_name}_profile_feature = doc.addObject('Part::Feature', {_json_ascii(_safe_name(f'{object_name}_profile', prefix='profile'))})",
+                f"    {var_name}_profile_feature.Shape = {var_name}_profile_shape",
+                f"    _set_visibility({var_name}_profile_feature, False)",
+                f"    {var_name}.Sections = [{var_name}_profile_feature]",
                 f"{var_name}.Spine = GRAPH_NODES[{_json_ascii(inputs[1])}]",
                 f"{var_name}.Solid = True",
                 f"{var_name}.Frenet = bool(_resolve_param_value({rp}, {re}, 'is_frenet') if 'is_frenet' in {rp} else False)",
@@ -2299,7 +2707,10 @@ def _joint_reference_from_anchor(anchor):
             lines = [
                 f"{var_name} = doc.addObject('Part::Fillet', {_json_ascii(object_name)})",
                 f"{var_name}.Base = GRAPH_NODES[{_json_ascii(inputs[0])}]",
-                f"{var_name}.Edges = [(int(idx) + 1, float(_resolve_param_value({rp}, {re}, 'radius')), float(_resolve_param_value({rp}, {re}, 'radius'))) for idx in {rp}.get('selected_edge_indices', [])]",
+                f"{var_name}_edge_indices = _match_subshape_indices(GRAPH_NODES[{_json_ascii(inputs[0])}], {rp}, 'edge', 'fillet_edge')",
+                f"if {var_name}_edge_indices is None:",
+                f"    {var_name}_edge_indices = _legacy_edge_indices({rp})",
+                f"{var_name}.Edges = [(int(idx), float(_resolve_param_value({rp}, {re}, 'radius')), float(_resolve_param_value({rp}, {re}, 'radius'))) for idx in {var_name}_edge_indices]",
             ]
             lines.append(f"_apply_detail_feature_bindings({var_name}, {re}, 'radius')")
             lines.extend(finish())
@@ -2309,7 +2720,10 @@ def _joint_reference_from_anchor(anchor):
             lines = [
                 f"{var_name} = doc.addObject('Part::Chamfer', {_json_ascii(object_name)})",
                 f"{var_name}.Base = GRAPH_NODES[{_json_ascii(inputs[0])}]",
-                f"{var_name}.Edges = [(int(idx) + 1, float(_resolve_param_value({rp}, {re}, 'distance')), float(_resolve_param_value({rp}, {re}, 'distance'))) for idx in {rp}.get('selected_edge_indices', [])]",
+                f"{var_name}_edge_indices = _match_subshape_indices(GRAPH_NODES[{_json_ascii(inputs[0])}], {rp}, 'edge', 'chamfer_edge')",
+                f"if {var_name}_edge_indices is None:",
+                f"    {var_name}_edge_indices = _legacy_edge_indices({rp})",
+                f"{var_name}.Edges = [(int(idx), float(_resolve_param_value({rp}, {re}, 'distance')), float(_resolve_param_value({rp}, {re}, 'distance'))) for idx in {var_name}_edge_indices]",
             ]
             lines.append(
                 f"_apply_detail_feature_bindings({var_name}, {re}, 'distance')"
@@ -2325,8 +2739,15 @@ def _joint_reference_from_anchor(anchor):
             lines.append(
                 f"_apply_op_expression_bindings({var_name}, {_json_ascii(node.op)}, {re})"
             )
-            if node.params.get("selected_face_indices"):
-                face_name_expr = f"['Face' + str(int(i) + 1) for i in {rp}.get('selected_face_indices', [])]"
+            if node.params.get("selected_subshapes") or node.params.get(
+                "selected_face_indices"
+            ):
+                face_name_expr = f"['Face' + str(int(i)) for i in {var_name}_face_indices]"
+                lines.append(
+                    f"{var_name}_face_indices = _match_subshape_indices(GRAPH_NODES[{_json_ascii(inputs[0])}], {rp}, 'face', 'shell_remove_face')"
+                )
+                lines.append(f"if {var_name}_face_indices is None:")
+                lines.append(f"    {var_name}_face_indices = [int(name[4:]) for name in _legacy_face_names({rp})]")
                 lines.append(
                     f"{var_name}.Faces = (GRAPH_NODES[{_json_ascii(inputs[0])}], {face_name_expr})"
                 )

--- a/src/simplecadapi/graph.py
+++ b/src/simplecadapi/graph.py
@@ -113,19 +113,38 @@ def _extract_input_nodes(inputs: Optional[Iterable[Any]]) -> List[OperationNode]
         return []
 
     nodes: List[OperationNode] = []
-    seen: Set[str] = set()
+    def _append_node(node: Any) -> None:
+        if node is None:
+            return
+        node_id = getattr(node, "node_id", None)
+        if node_id is None:
+            return
+        nodes.append(node)
+
     for obj in inputs:
         if obj is None:
             continue
         node = getattr(obj, "_get_runtime", lambda *_args, **_kwargs: None)(
             "graph.node"
         )
-        if node is None:
+        _append_node(node)
+        if node is not None:
             continue
-        if node.node_id in seen:
+
+        topo_ref = getattr(obj, "_get_runtime", lambda *_args, **_kwargs: None)(
+            "topo.ref"
+        )
+        node_id = getattr(topo_ref, "node_id", None)
+        if not node_id:
+            topo_ref_meta = getattr(obj, "get_metadata", lambda *_args, **_kwargs: None)(
+                "topo_ref"
+            )
+            if isinstance(topo_ref_meta, dict):
+                node_id = topo_ref_meta.get("node_id")
+        session = get_active_session()
+        if session is None or not node_id:
             continue
-        seen.add(node.node_id)
-        nodes.append(node)
+        _append_node(session.graph.get_node(str(node_id)))
     return nodes
 
 

--- a/src/simplecadapi/operations.py
+++ b/src/simplecadapi/operations.py
@@ -597,6 +597,40 @@ def _selected_subshape_from_existing_shape(
     return payload
 
 
+def _selected_subshapes_from_existing_shapes(
+    owner: AnyShape,
+    selected_shapes: Sequence[AnyShape],
+    *,
+    kind: str,
+    role: str,
+) -> Dict[str, object]:
+    methods = [_selection_method_for_shape(shape) for shape in selected_shapes]
+    method = methods[0] if methods and all(value == methods[0] for value in methods) else "index"
+    payload = _serialize_selected_subshapes(
+        owner,
+        selected_shapes,
+        kind=kind,
+        role=role,
+        selection=None,
+    )
+    payload["selection_method"] = method
+    for item, shape in zip(
+        cast(List[Dict[str, object]], payload.get("items", [])), selected_shapes
+    ):
+        item["original_selection_method"] = _selection_method_for_shape(shape)
+        query = getattr(shape, "_get_runtime", lambda *_args, **_kwargs: None)(
+            "selection.query"
+        )
+        order = getattr(shape, "_get_runtime", lambda *_args, **_kwargs: None)(
+            "selection.order"
+        )
+        if isinstance(query, dict):
+            item["selection_query_debug"] = query
+        if order is not None:
+            item["original_slice_position"] = int(order)
+    return payload
+
+
 def _selected_subshape_owner(shape: AnyShape, expected_type: type) -> Optional[AnyShape]:
     for parent in shape.get_parents():
         if isinstance(parent, expected_type):
@@ -614,6 +648,141 @@ def _resolve_selector_or_shapes(
     if isinstance(selection, ShapeSelector):
         return cast(List[AnyShape], selection.resolve(scope))
     return list(selection)
+
+
+def _common_selected_subshape_owner(
+    shapes: Sequence[AnyShape],
+    expected_type: type,
+) -> Optional[AnyShape]:
+    owner: Optional[AnyShape] = None
+    for shape in shapes:
+        shape_owner = _selected_subshape_owner(shape, expected_type)
+        if shape_owner is None:
+            return None
+        if owner is None:
+            owner = shape_owner
+            continue
+        try:
+            if shape_owner is owner or shape_owner.same_topology(owner):
+                continue
+        except Exception:
+            if shape_owner is owner:
+                continue
+        return None
+    return owner
+
+
+def _selected_subshape_owners(
+    shapes: Sequence[AnyShape],
+    expected_type: type,
+) -> Optional[List[AnyShape]]:
+    owners: List[AnyShape] = []
+    for shape in shapes:
+        owner = _selected_subshape_owner(shape, expected_type)
+        if owner is None:
+            return None
+        owners.append(owner)
+    return owners
+
+
+def _wire_selected_subshape_owner(wire: Wire) -> Optional[Solid]:
+    return _common_selected_subshape_owner(wire.get_edges(), Solid)
+
+
+def _wire_selected_subshapes(wire: Wire, *, role: str) -> Optional[Dict[str, object]]:
+    edges = wire.get_edges()
+    owner = _common_selected_subshape_owner(edges, Solid)
+    if owner is None:
+        return None
+    return _selected_subshapes_from_existing_shapes(
+        owner,
+        edges,
+        kind="edge",
+        role=role,
+    )
+
+
+def _selected_subshapes_from_existing_shape_owners(
+    owners: Sequence[AnyShape],
+    selected_shapes: Sequence[AnyShape],
+    *,
+    kind: str,
+    role: str,
+) -> Dict[str, object]:
+    if len(owners) != len(selected_shapes):
+        raise ValueError("owner and selected shape counts must match")
+    payload = _selected_subshapes_from_existing_shapes(
+        owners[0],
+        selected_shapes,
+        kind=kind,
+        role=role,
+    )
+    items = cast(List[Dict[str, object]], payload.get("items", []))
+    for item, owner in zip(items, owners):
+        source = _shape_source_payload(owner)
+        item["source"] = source
+        item["source_shape_node"] = source.get("node_id")
+    unique_sources: List[Dict[str, object]] = []
+    seen: set[tuple[object, object, object]] = set()
+    for owner in owners:
+        source = _shape_source_payload(owner)
+        key = (source.get("graph_id"), source.get("node_id"), source.get("output_slot", 0))
+        if key in seen:
+            continue
+        seen.add(key)
+        unique_sources.append(source)
+    payload["sources"] = unique_sources
+    if len(unique_sources) == 1:
+        payload["source"] = unique_sources[0]
+        payload["source_shape_node"] = unique_sources[0].get("node_id")
+    else:
+        payload["source"] = {}
+        payload["source_shape_node"] = None
+    return payload
+
+
+def _selected_subshape_payload_for_shape(
+    shape: AnyShape,
+    *,
+    role_prefix: str,
+) -> tuple[Optional[Dict[str, object]], Optional[AnyShape], Optional[str]]:
+    if isinstance(shape, Edge):
+        owner = _selected_subshape_owner(shape, Solid)
+        if owner is None:
+            return None, None, None
+        return (
+            _selected_subshape_from_existing_shape(
+                owner,
+                shape,
+                kind="edge",
+                role=f"{role_prefix}_source_edge",
+            ),
+            owner,
+            "edge",
+        )
+    if isinstance(shape, Face):
+        owner = _selected_subshape_owner(shape, Solid)
+        if owner is None:
+            return None, None, None
+        return (
+            _selected_subshape_from_existing_shape(
+                owner,
+                shape,
+                kind="face",
+                role=f"{role_prefix}_source_face",
+            ),
+            owner,
+            "face",
+        )
+    if isinstance(shape, Wire):
+        owner = _wire_selected_subshape_owner(shape)
+        selected_edges = _wire_selected_subshapes(
+            shape, role=f"{role_prefix}_source_edge"
+        )
+        if owner is None or selected_edges is None:
+            return None, None, None
+        return selected_edges, owner, "wire"
+    return None, None, None
 
 
 def _serialize_selection_query(
@@ -1270,13 +1439,21 @@ def make_face_from_wire_rface(
         face._tags = wire._tags.copy()
         face._metadata = wire._metadata.copy()
 
+        params: Dict[str, object] = {"normal": normal}
+        input_shapes: Sequence[AnyShape] = [wire]
+        selected_edges = _wire_selected_subshapes(wire, role="face_boundary_edge")
+        owner = _wire_selected_subshape_owner(wire)
+        if selected_edges is not None and owner is not None:
+            params["selected_subshapes"] = selected_edges
+            input_shapes = [owner]
+
         return cast(
             Face,
             _finalize_derived_shape(
                 face,
                 op=_OP_MAKE_FACE_FROM_WIRE_RFACE,
-                params={"normal": normal},
-                input_shapes=[wire],
+                params=params,
+                input_shapes=input_shapes,
                 tags={"derived", "face"},
             ),
         )
@@ -1584,13 +1761,24 @@ def make_wire_from_edges_rwire(edges: List[Edge]) -> Wire:
             raise ValueError("边列表不能为空")
 
         wire_shape = make_wire_from_edges_ocp([edge.wrapped for edge in edges])
+        params: Dict[str, object] = {"edge_count": len(edges)}
+        input_shapes: Sequence[AnyShape] = edges
+        owners = _selected_subshape_owners(edges, Solid)
+        if owners is not None:
+            params["selected_subshapes"] = _selected_subshapes_from_existing_shape_owners(
+                owners,
+                edges,
+                kind="edge",
+                role="wire_edge",
+            )
+            input_shapes = owners
         return cast(
             Wire,
             _finalize_derived_shape(
                 Wire(wire_shape),
                 op=_OP_MAKE_WIRE_FROM_EDGES_RWIRE,
-                params={"edge_count": len(edges)},
-                input_shapes=edges,
+                params=params,
+                input_shapes=input_shapes,
                 tags={"derived", "wire"},
             ),
         )
@@ -2618,11 +2806,22 @@ def translate_shape(shape: AnyShape, vector: Tuple[float, float, float]) -> AnyS
         new_shape._tags = shape._tags.copy()
         new_shape._metadata = shape._metadata.copy()
         _copy_runtime_state(shape, new_shape)
+        params: Dict[str, object] = {"vector": vector}
+        input_shapes: Sequence[AnyShape] = [shape]
+        selection_payload, owner, selected_kind = _selected_subshape_payload_for_shape(
+            shape, role_prefix="translate"
+        )
+        if selection_payload is not None and owner is not None:
+            params["selected_subshapes"] = selection_payload
+            if selected_kind is not None:
+                params["selected_source_kind"] = selected_kind
+            input_shapes = [owner]
+
         record_operation_if_active(
             op=_OP_MAKE_TRANSLATE_RSHAPE,
-            params={"vector": vector},
+            params=params,
             outputs=new_shape,
-            input_shapes=[shape],
+            input_shapes=input_shapes,
             context=_current_context_metadata(),
         )
 
@@ -2698,11 +2897,22 @@ def rotate_shape(
             new_shape._tags = shape._tags.copy()
             new_shape._metadata = shape._metadata.copy()
             _copy_runtime_state(shape, new_shape)
+            params: Dict[str, object] = {"angle": angle, "axis": axis, "origin": origin}
+            input_shapes: Sequence[AnyShape] = [shape]
+            selection_payload, owner, selected_kind = _selected_subshape_payload_for_shape(
+                shape, role_prefix="rotate"
+            )
+            if selection_payload is not None and owner is not None:
+                params["selected_subshapes"] = selection_payload
+                if selected_kind is not None:
+                    params["selected_source_kind"] = selected_kind
+                input_shapes = [owner]
+
             record_operation_if_active(
                 op=_OP_MAKE_ROTATE_RSHAPE,
-                params={"angle": angle, "axis": axis, "origin": origin},
+                params=params,
                 outputs=new_shape,
-                input_shapes=[shape],
+                input_shapes=input_shapes,
                 context=_current_context_metadata(),
             )
 
@@ -2807,16 +3017,28 @@ def extrude_rsolid(
         solid.add_tag("extrusion solid")
         solid._metadata = profile._metadata.copy()
 
+        params: Dict[str, object] = {
+            "direction": direction,
+            "distance": distance,
+        }
+        input_shapes: Sequence[AnyShape] = [profile]
+        profile_owner = _selected_subshape_owner(face, Solid)
+        if profile_owner is not None:
+            params["selected_subshapes"] = _selected_subshape_from_existing_shape(
+                profile_owner,
+                face,
+                kind="face",
+                role="extrude_profile_face",
+            )
+            input_shapes = [profile_owner]
+
         return _finalize_tracked_solid(
             solid,
             op=_OP_MAKE_EXTRUDE_RSOLID,
-            params={
-                "direction": direction,
-                "distance": distance,
-            },
+            params=params,
             delta=tracked.delta,
             delta_entries=cast(Dict[str, Dict[str, object]], tracked.delta_entries),
-            input_shapes=[profile],
+            input_shapes=input_shapes,
         )
     except Exception as e:
         _wrap_public_api_error(
@@ -2888,17 +3110,29 @@ def revolve_rsolid(
         solid._tags = profile._tags.copy()
         solid._metadata = profile._metadata.copy()
 
+        params = {
+            "axis": axis,
+            "angle": angle,
+            "origin": origin,
+        }
+        input_shapes = [profile]
+        profile_owner = _selected_subshape_owner(face, Solid)
+        if profile_owner is not None:
+            params["selected_subshapes"] = _selected_subshape_from_existing_shape(
+                profile_owner,
+                face,
+                kind="face",
+                role="revolve_profile_face",
+            )
+            input_shapes = [profile_owner]
+
         return _finalize_tracked_solid(
             solid,
             op=_OP_MAKE_REVOLVE_RSOLID,
-            params={
-                "axis": axis,
-                "angle": angle,
-                "origin": origin,
-            },
+            params=params,
             delta=tracked.delta,
             delta_entries=cast(Dict[str, Dict[str, object]], tracked.delta_entries),
-            input_shapes=[profile],
+            input_shapes=input_shapes,
         )
     except Exception as e:
         _wrap_public_api_error(
@@ -4226,13 +4460,33 @@ def loft_rsolid(profiles: List[Wire], ruled: bool = False) -> Solid:
         result._tags = all_tags
         result._metadata = all_metadata
 
+        params: Dict[str, object] = {"profile_count": len(profiles), "ruled": ruled}
+        input_shapes: Sequence[AnyShape] = profiles
+        selected_profile_edges: List[Dict[str, object]] = []
+        profile_owners: List[AnyShape] = []
+        for profile_index, profile in enumerate(profiles):
+            owner = _wire_selected_subshape_owner(profile)
+            selected_edges = _wire_selected_subshapes(
+                profile,
+                role=f"loft_profile_{profile_index}_edge",
+            )
+            if owner is None or selected_edges is None:
+                selected_profile_edges = []
+                profile_owners = []
+                break
+            selected_profile_edges.append(selected_edges)
+            profile_owners.append(owner)
+        if selected_profile_edges:
+            params["selected_profile_subshapes"] = selected_profile_edges
+            input_shapes = profile_owners
+
         return _finalize_tracked_solid(
             result,
             op=_OP_MAKE_LOFT_RSOLID,
-            params={"profile_count": len(profiles), "ruled": ruled},
+            params=params,
             delta=tracked.delta,
             delta_entries=cast(Dict[str, Dict[str, object]], tracked.delta_entries),
-            input_shapes=profiles,
+            input_shapes=input_shapes,
         )
     except Exception as e:
         _wrap_public_api_error(
@@ -4274,6 +4528,11 @@ def sweep_rsolid(profile: Face, path: Wire, is_frenet: bool = False) -> Solid:
                 role="sweep_profile_face",
             )
             input_shapes = [profile_owner, path]
+        path_owner = _wire_selected_subshape_owner(path)
+        selected_path_edges = _wire_selected_subshapes(path, role="sweep_path_edge")
+        if selected_path_edges is not None and path_owner is not None:
+            params["selected_path_subshapes"] = selected_path_edges
+            input_shapes = [input_shapes[0], path_owner]
 
         return _finalize_tracked_solid(
             result,
@@ -4525,14 +4784,25 @@ def mirror_shape(
         new_shape.add_tag("mirrored")
 
         _attach_track_summary(new_shape, op=_OP_MAKE_MIRROR_RSHAPE)
+        params: Dict[str, object] = {
+            "plane_origin": plane_origin,
+            "plane_normal": plane_normal,
+        }
+        input_shapes: Sequence[AnyShape] = [shape]
+        selection_payload, owner, selected_kind = _selected_subshape_payload_for_shape(
+            shape, role_prefix="mirror"
+        )
+        if selection_payload is not None and owner is not None:
+            params["selected_subshapes"] = selection_payload
+            if selected_kind is not None:
+                params["selected_source_kind"] = selected_kind
+            input_shapes = [owner]
+
         record_operation_if_active(
             op=_OP_MAKE_MIRROR_RSHAPE,
-            params={
-                "plane_origin": plane_origin,
-                "plane_normal": plane_normal,
-            },
+            params=params,
             outputs=new_shape,
-            input_shapes=[shape],
+            input_shapes=input_shapes,
             context=_current_context_metadata(),
         )
 

--- a/src/simplecadapi/operations.py
+++ b/src/simplecadapi/operations.py
@@ -96,6 +96,7 @@ from .kernel.ocp_booleans import common_shapes, fuse_shapes, solids_of
 from .kernel.ocp_export import export_step_shapes, export_stl_shape, make_compound
 from .kernel.ocp_mesh import make_triangle_face, shell_is_closed, shell_metric, solid_from_shell, tessellate_face
 from .kernel.ocp_properties import bounding_box, distance as ocp_distance
+from .selection_signature import extract_geometry_signature
 
 
 _DEFAULT_UNION_GLUE = True
@@ -361,6 +362,9 @@ def _vector_like_to_tuple(value: Any) -> Optional[Tuple[float, float, float]]:
 
 
 def _make_selector_hint(shape: AnyShape) -> Dict[str, object]:
+    if isinstance(shape, (Edge, Face)):
+        return cast(Dict[str, object], extract_geometry_signature(shape))
+
     hint: Dict[str, object] = {
         "kind": type(shape).__name__.lower(),
         "tags": sorted(shape.get_tags()),
@@ -455,6 +459,152 @@ def _serialize_selection_indices(
         if topo_id in candidate_index_by_topo_id:
             result.append(candidate_index_by_topo_id[topo_id])
     return result
+
+
+def _selection_index_for_shape(
+    selected_shape: AnyShape, candidates: Sequence[AnyShape]
+) -> Optional[int]:
+    selected_topo_id = _shape_ref_topo_id(selected_shape)
+    for idx, candidate in enumerate(candidates):
+        candidate_topo_id = _shape_ref_topo_id(candidate)
+        if (
+            selected_topo_id is not None
+            and candidate_topo_id is not None
+            and selected_topo_id == candidate_topo_id
+        ):
+            return idx
+        try:
+            if selected_shape.same_topology(candidate):
+                return idx
+        except Exception:
+            pass
+    return None
+
+
+def _shape_source_payload(
+    shape: AnyShape, fallback_owner: Optional[AnyShape] = None
+) -> Dict[str, object]:
+    ref = _serialize_shape_ref(shape)
+    if ref is None and fallback_owner is not None:
+        ref = _serialize_shape_ref(fallback_owner)
+    if ref is None:
+        return {}
+    return {
+        "graph_id": ref.get("graph_id"),
+        "node_id": ref.get("node_id"),
+        "output_slot": ref.get("output_slot", 0),
+    }
+
+
+def _selected_subshape_item_id(
+    *, role: str, kind: str, order: int, shape: AnyShape
+) -> str:
+    topo_id = _shape_ref_topo_id(shape) or getattr(shape, "topo_id", None) or id(shape)
+    token = "".join(ch if str(ch).isalnum() else "_" for ch in str(topo_id)).strip("_")
+    return f"{role}_{kind}_{int(order)}_{token or 'shape'}"
+
+
+def _serialize_selected_subshapes(
+    owner: AnyShape,
+    selected_shapes: Sequence[AnyShape],
+    *,
+    kind: str,
+    role: str,
+    selection: Optional[Union[Sequence[AnyShape], ShapeSelector]] = None,
+) -> Dict[str, object]:
+    method = "ql" if isinstance(selection, ShapeSelector) else "index"
+    if kind == "edge" and hasattr(owner, "get_edges"):
+        candidates = list(cast(Any, owner).get_edges())
+    elif kind == "face" and hasattr(owner, "get_faces"):
+        candidates = list(cast(Any, owner).get_faces())
+    else:
+        candidates = list(selected_shapes)
+
+    items: List[Dict[str, object]] = []
+    for order, shape in enumerate(selected_shapes):
+        source = _shape_source_payload(shape, owner)
+        item: Dict[str, object] = {
+            "item_id": _selected_subshape_item_id(
+                role=role, kind=kind, order=order, shape=shape
+            ),
+            "kind": kind,
+            "role": role,
+            "source": source,
+            "source_shape_node": source.get("node_id"),
+            "geometry_signature": extract_geometry_signature(shape),
+            "original_selection_method": method,
+            "original_slice_position": order,
+            "order": order,
+        }
+        original_index = _selection_index_for_shape(shape, candidates)
+        if original_index is not None:
+            item["original_index"] = original_index
+        items.append(item)
+
+    owner_source = _shape_source_payload(owner)
+    payload: Dict[str, object] = {
+        "schema_version": "selected_subshapes.v1",
+        "source": owner_source,
+        "source_shape_node": owner_source.get("node_id"),
+        "kind": kind,
+        "role": role,
+        "selection_method": method,
+        "item_count": len(items),
+        "items": items,
+        "allow_duplicate_matches": False,
+    }
+    query = _serialize_selection_query(selection) if selection is not None else None
+    if query is not None:
+        payload["selection_query_debug"] = query
+    return payload
+
+
+def _selection_method_for_shape(shape: AnyShape, fallback: str = "index") -> str:
+    value = getattr(shape, "_get_runtime", lambda *_args, **_kwargs: None)(
+        "selection.method"
+    )
+    return str(value) if value is not None else fallback
+
+
+def _selected_subshape_from_existing_shape(
+    owner: AnyShape,
+    selected_shape: AnyShape,
+    *,
+    kind: str,
+    role: str,
+) -> Dict[str, object]:
+    method = _selection_method_for_shape(selected_shape)
+    payload = _serialize_selected_subshapes(
+        owner,
+        [selected_shape],
+        kind=kind,
+        role=role,
+        selection=None,
+    )
+    payload["selection_method"] = method
+    for item in cast(List[Dict[str, object]], payload.get("items", [])):
+        item["original_selection_method"] = method
+        query = getattr(selected_shape, "_get_runtime", lambda *_args, **_kwargs: None)(
+            "selection.query"
+        )
+        order = getattr(selected_shape, "_get_runtime", lambda *_args, **_kwargs: None)(
+            "selection.order"
+        )
+        if isinstance(query, dict):
+            item["selection_query_debug"] = query
+        if order is not None:
+            item["original_slice_position"] = int(order)
+    return payload
+
+
+def _selected_subshape_owner(shape: AnyShape, expected_type: type) -> Optional[AnyShape]:
+    for parent in shape.get_parents():
+        if isinstance(parent, expected_type):
+            return parent
+        owner = _selected_subshape_owner(parent, expected_type)
+        if owner is not None:
+            return owner
+    return None
 
 
 def _resolve_selector_or_shapes(
@@ -3880,6 +4030,13 @@ def fillet_rsolid(
             params={
                 "radius": radius,
                 "edge_count": len(selected_edges),
+                "selected_subshapes": _serialize_selected_subshapes(
+                    solid,
+                    selected_edges,
+                    kind="edge",
+                    role="fillet_edge",
+                    selection=edges,
+                ),
                 "selected_edges": _serialize_shape_refs(selected_edges),
                 "selected_edge_indices": _serialize_selection_indices(
                     selected_edges, solid.get_edges()
@@ -3939,6 +4096,13 @@ def chamfer_rsolid(
             params={
                 "distance": distance,
                 "edge_count": len(selected_edges),
+                "selected_subshapes": _serialize_selected_subshapes(
+                    solid,
+                    selected_edges,
+                    kind="edge",
+                    role="chamfer_edge",
+                    selection=edges,
+                ),
                 "selected_edges": _serialize_shape_refs(selected_edges),
                 "selected_edge_indices": _serialize_selection_indices(
                     selected_edges, solid.get_edges()
@@ -4003,6 +4167,13 @@ def shell_rsolid(
             params={
                 "thickness": thickness,
                 "removed_face_count": len(selected_faces),
+                "selected_subshapes": _serialize_selected_subshapes(
+                    solid,
+                    selected_faces,
+                    kind="face",
+                    role="shell_remove_face",
+                    selection=faces_to_remove,
+                ),
                 "selected_faces": _serialize_shape_refs(selected_faces),
                 "selected_face_indices": _serialize_selection_indices(
                     selected_faces, solid.get_faces()
@@ -4092,13 +4263,25 @@ def sweep_rsolid(profile: Face, path: Wire, is_frenet: bool = False) -> Solid:
         result._tags = profile._tags.union(path._tags)
         result._metadata = {**profile._metadata, **path._metadata}
 
+        input_shapes: List[AnyShape] = [profile, path]
+        params: Dict[str, object] = {"is_frenet": bool(is_frenet)}
+        profile_owner = _selected_subshape_owner(profile, Solid)
+        if profile_owner is not None:
+            params["selected_subshapes"] = _selected_subshape_from_existing_shape(
+                profile_owner,
+                profile,
+                kind="face",
+                role="sweep_profile_face",
+            )
+            input_shapes = [profile_owner, path]
+
         return _finalize_tracked_solid(
             result,
             op=_OP_MAKE_SWEEP_RSOLID,
-            params={"is_frenet": bool(is_frenet)},
+            params=params,
             delta=tracked.delta,
             delta_entries=cast(Dict[str, Dict[str, object]], tracked.delta_entries),
-            input_shapes=[profile, path],
+            input_shapes=input_shapes,
         )
     except Exception as e:
         _wrap_public_api_error(

--- a/src/simplecadapi/ql.py
+++ b/src/simplecadapi/ql.py
@@ -517,6 +517,12 @@ class ShapeSelector:
             raise ValueError(
                 f"QL selector expected exactly {exact} {self.target_kind}(s), got {len(items)}"
             )
+        for order, item in enumerate(items):
+            setter = getattr(item, "_set_runtime", None)
+            if callable(setter):
+                setter("selection.method", "ql")
+                setter("selection.query", self.to_dict())
+                setter("selection.order", order)
         return list(items)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/src/simplecadapi/selection_signature.py
+++ b/src/simplecadapi/selection_signature.py
@@ -1,0 +1,521 @@
+"""Geometry signatures for runtime-selected subshapes.
+
+The signatures in this module are intentionally descriptive rather than
+topological.  They capture the face/edge that the SimpleCAD runtime actually
+selected so another kernel can re-identify the corresponding subshape without
+trusting SimpleCAD/OCP traversal indices.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, TypeVar, cast
+
+from OCP.BRepAdaptor import BRepAdaptor_Curve, BRepAdaptor_Surface
+from OCP.GeomAbs import (
+    GeomAbs_BSplineCurve,
+    GeomAbs_BSplineSurface,
+    GeomAbs_BezierCurve,
+    GeomAbs_BezierSurface,
+    GeomAbs_Circle,
+    GeomAbs_Cone,
+    GeomAbs_Cylinder,
+    GeomAbs_Line,
+    GeomAbs_Plane,
+    GeomAbs_Sphere,
+    GeomAbs_Torus,
+)
+from OCP.gp import gp_Pnt, gp_Vec
+
+from .core import AnyShape, Edge, Face
+from .kernel.ocp_properties import bounding_box
+
+
+_POINT_ABS_TOL = 1e-5
+_REL_TOL = 1e-6
+
+
+TShape = TypeVar("TShape", Edge, Face)
+
+
+def _tuple3(value: Any) -> Optional[Tuple[float, float, float]]:
+    if value is None:
+        return None
+    if hasattr(value, "x") and hasattr(value, "y") and hasattr(value, "z"):
+        return (float(value.x), float(value.y), float(value.z))
+    if hasattr(value, "X") and hasattr(value, "Y") and hasattr(value, "Z"):
+        return (float(value.X()), float(value.Y()), float(value.Z()))
+    if isinstance(value, (list, tuple)) and len(value) == 3:
+        return (float(value[0]), float(value[1]), float(value[2]))
+    return None
+
+
+def _point_payload(value: Any) -> Optional[List[float]]:
+    vec = _tuple3(value)
+    if vec is None:
+        return None
+    return [float(vec[0]), float(vec[1]), float(vec[2])]
+
+
+def _normalized(value: Any) -> Optional[List[float]]:
+    vec = _tuple3(value)
+    if vec is None:
+        return None
+    length = math.sqrt(vec[0] * vec[0] + vec[1] * vec[1] + vec[2] * vec[2])
+    if length <= 1e-12:
+        return None
+    return [vec[0] / length, vec[1] / length, vec[2] / length]
+
+
+def _bbox_payload(shape: Any) -> Dict[str, List[float]]:
+    bb = bounding_box(shape)
+    return {
+        "min": [float(bb.xmin), float(bb.ymin), float(bb.zmin)],
+        "max": [float(bb.xmax), float(bb.ymax), float(bb.zmax)],
+        "size": [float(bb.xlen), float(bb.ylen), float(bb.zlen)],
+    }
+
+
+def _edge_curve_type(edge: Edge) -> str:
+    try:
+        adaptor = BRepAdaptor_Curve(edge.wrapped)
+        curve_type = adaptor.GetType()
+        if curve_type == GeomAbs_Line:
+            return "line"
+        if curve_type == GeomAbs_Circle:
+            span = abs(float(adaptor.LastParameter()) - float(adaptor.FirstParameter()))
+            return "circle" if abs(span - (2.0 * math.pi)) <= 1e-5 else "arc"
+        if curve_type == GeomAbs_BSplineCurve:
+            return "bspline"
+        if curve_type == GeomAbs_BezierCurve:
+            return "bezier"
+        return str(curve_type).replace("GeomAbs_CurveType.GeomAbs_", "").lower()
+    except Exception:
+        return "unknown"
+
+
+def _face_surface_type(face: Face) -> str:
+    try:
+        adaptor = BRepAdaptor_Surface(face.wrapped)
+        surface_type = adaptor.GetType()
+        mapping = {
+            GeomAbs_Plane: "plane",
+            GeomAbs_Cylinder: "cylinder",
+            GeomAbs_Cone: "cone",
+            GeomAbs_Sphere: "sphere",
+            GeomAbs_Torus: "torus",
+            GeomAbs_BSplineSurface: "bspline",
+            GeomAbs_BezierSurface: "bezier",
+        }
+        return mapping.get(
+            surface_type,
+            str(surface_type).replace("GeomAbs_SurfaceType.GeomAbs_", "").lower(),
+        )
+    except Exception:
+        return "unknown"
+
+
+def _edge_endpoints(edge: Edge) -> Optional[List[List[float]]]:
+    try:
+        return [
+            [float(v) for v in edge.get_start_vertex().get_coordinates()],
+            [float(v) for v in edge.get_end_vertex().get_coordinates()],
+        ]
+    except Exception:
+        pass
+
+    try:
+        adaptor = BRepAdaptor_Curve(edge.wrapped)
+        first = float(adaptor.FirstParameter())
+        last = float(adaptor.LastParameter())
+        return [
+            cast(List[float], _point_payload(adaptor.Value(first))),
+            cast(List[float], _point_payload(adaptor.Value(last))),
+        ]
+    except Exception:
+        return None
+
+
+def _edge_midpoint(edge: Edge) -> Optional[List[float]]:
+    try:
+        adaptor = BRepAdaptor_Curve(edge.wrapped)
+        mid = 0.5 * (float(adaptor.FirstParameter()) + float(adaptor.LastParameter()))
+        return _point_payload(adaptor.Value(mid))
+    except Exception:
+        return _point_payload(edge.get_center())
+
+
+def _edge_tangent(edge: Edge) -> Optional[List[float]]:
+    try:
+        adaptor = BRepAdaptor_Curve(edge.wrapped)
+        mid = 0.5 * (float(adaptor.FirstParameter()) + float(adaptor.LastParameter()))
+        point = gp_Pnt()
+        tangent = gp_Vec()
+        adaptor.D1(mid, point, tangent)
+        return _normalized(tangent)
+    except Exception:
+        pass
+
+    endpoints = _edge_endpoints(edge)
+    if endpoints and len(endpoints) == 2:
+        start, end = endpoints
+        return _normalized(
+            (
+                float(end[0]) - float(start[0]),
+                float(end[1]) - float(start[1]),
+                float(end[2]) - float(start[2]),
+            )
+        )
+    return None
+
+
+def _edge_radius(edge: Edge) -> Optional[float]:
+    try:
+        adaptor = BRepAdaptor_Curve(edge.wrapped)
+        if adaptor.GetType() == GeomAbs_Circle:
+            return float(adaptor.Circle().Radius())
+    except Exception:
+        pass
+    return None
+
+
+def _face_radius(face: Face) -> Optional[float]:
+    try:
+        adaptor = BRepAdaptor_Surface(face.wrapped)
+        surface_type = adaptor.GetType()
+        if surface_type == GeomAbs_Cylinder:
+            return float(adaptor.Cylinder().Radius())
+        if surface_type == GeomAbs_Cone:
+            return float(adaptor.Cone().RefRadius())
+        if surface_type == GeomAbs_Sphere:
+            return float(adaptor.Sphere().Radius())
+        if surface_type == GeomAbs_Torus:
+            return float(adaptor.Torus().MajorRadius())
+    except Exception:
+        pass
+    return None
+
+
+def extract_geometry_signature(shape: AnyShape) -> Dict[str, Any]:
+    """Return a JSON-compatible geometry signature for a selected face or edge."""
+
+    if isinstance(shape, Edge):
+        signature: Dict[str, Any] = {
+            "kind": "edge",
+            "curve_type": _edge_curve_type(shape),
+            "length": float(shape.get_length()),
+            "bbox": _bbox_payload(shape.wrapped),
+            "tags": sorted(shape.get_tags()),
+        }
+        center = _point_payload(shape.get_center())
+        midpoint = _edge_midpoint(shape)
+        tangent = _edge_tangent(shape)
+        radius = _edge_radius(shape)
+        endpoints = _edge_endpoints(shape)
+        if center is not None:
+            signature["center"] = center
+        if midpoint is not None:
+            signature["midpoint"] = midpoint
+        if tangent is not None:
+            signature["tangent"] = tangent
+            signature["direction"] = tangent
+        if radius is not None:
+            signature["radius"] = radius
+        if endpoints is not None:
+            signature["endpoints"] = endpoints
+        return signature
+
+    if isinstance(shape, Face):
+        signature = {
+            "kind": "face",
+            "surface_type": _face_surface_type(shape),
+            "area": float(shape.get_area()),
+            "bbox": _bbox_payload(shape.wrapped),
+            "tags": sorted(shape.get_tags()),
+        }
+        center = _point_payload(shape.get_center())
+        if center is not None:
+            signature["center"] = center
+        try:
+            normal = _normalized(shape.get_normal_at())
+            if normal is not None:
+                signature["normal"] = normal
+        except Exception:
+            pass
+        radius = _face_radius(shape)
+        if radius is not None:
+            signature["radius"] = radius
+        return signature
+
+    raise TypeError(
+        f"Geometry signatures are supported for Edge and Face selections, got {type(shape).__name__}"
+    )
+
+
+def _bbox_scale(signature: Dict[str, Any]) -> float:
+    bbox = signature.get("bbox")
+    if isinstance(bbox, dict):
+        size = bbox.get("size")
+        if isinstance(size, (list, tuple)) and len(size) == 3:
+            try:
+                return max(
+                    math.sqrt(sum(float(v) * float(v) for v in size)),
+                    _POINT_ABS_TOL,
+                )
+            except Exception:
+                pass
+    for key in ("length", "radius"):
+        if key in signature:
+            try:
+                return max(abs(float(signature[key])), _POINT_ABS_TOL)
+            except Exception:
+                pass
+    if "area" in signature:
+        try:
+            return max(math.sqrt(abs(float(signature["area"]))), _POINT_ABS_TOL)
+        except Exception:
+            pass
+    return 1.0
+
+
+def _point_tol(target: Dict[str, Any], candidate: Dict[str, Any]) -> float:
+    return max(_POINT_ABS_TOL, _bbox_scale(target) * _REL_TOL, _bbox_scale(candidate) * _REL_TOL)
+
+
+def _scalar_close(a: Any, b: Any) -> bool:
+    try:
+        af = float(a)
+        bf = float(b)
+    except Exception:
+        return False
+    return abs(af - bf) <= max(1e-7, abs(af) * _REL_TOL, abs(bf) * _REL_TOL)
+
+
+def _distance(a: Any, b: Any) -> Optional[float]:
+    av = _tuple3(a)
+    bv = _tuple3(b)
+    if av is None or bv is None:
+        return None
+    return math.dist(av, bv)
+
+
+def _vec_close(a: Any, b: Any, tol: float) -> bool:
+    dist = _distance(a, b)
+    return dist is not None and dist <= tol
+
+
+def _direction_close(a: Any, b: Any) -> bool:
+    av = _normalized(a)
+    bv = _normalized(b)
+    if av is None or bv is None:
+        return False
+    dot = abs(av[0] * bv[0] + av[1] * bv[1] + av[2] * bv[2])
+    return dot >= 1.0 - 1e-5
+
+
+def _bbox_close(a: Any, b: Any, tol: float) -> bool:
+    if not isinstance(a, dict) or not isinstance(b, dict):
+        return False
+    for key in ("min", "max"):
+        if not _vec_close(a.get(key), b.get(key), tol):
+            return False
+    return True
+
+
+def _endpoints_close(a: Any, b: Any, tol: float) -> bool:
+    if not (
+        isinstance(a, (list, tuple))
+        and isinstance(b, (list, tuple))
+        and len(a) == 2
+        and len(b) == 2
+    ):
+        return False
+    direct = _vec_close(a[0], b[0], tol) and _vec_close(a[1], b[1], tol)
+    reverse = _vec_close(a[0], b[1], tol) and _vec_close(a[1], b[0], tol)
+    return direct or reverse
+
+
+def signatures_match(
+    candidate: Dict[str, Any],
+    target: Dict[str, Any],
+    *,
+    kind: str,
+) -> bool:
+    """Return True when a candidate signature matches a stored target signature."""
+
+    target_kind = str(target.get("kind", kind)).lower()
+    candidate_kind = str(candidate.get("kind", kind)).lower()
+    if target_kind != candidate_kind or target_kind != str(kind).lower():
+        return False
+
+    compared = 0
+    tol = _point_tol(target, candidate)
+
+    type_key = "curve_type" if kind == "edge" else "surface_type"
+    if target.get(type_key) and candidate.get(type_key):
+        compared += 1
+        if str(target[type_key]).lower() != str(candidate[type_key]).lower():
+            return False
+
+    for key in ("length", "area", "radius"):
+        if key in target and key in candidate:
+            compared += 1
+            if not _scalar_close(target[key], candidate[key]):
+                return False
+
+    for key in ("center", "midpoint"):
+        if key in target and key in candidate:
+            compared += 1
+            if not _vec_close(target[key], candidate[key], tol):
+                return False
+
+    for key in ("normal", "tangent", "direction"):
+        if key in target and key in candidate:
+            compared += 1
+            if not _direction_close(target[key], candidate[key]):
+                return False
+
+    if "bbox" in target and "bbox" in candidate:
+        compared += 1
+        if not _bbox_close(target["bbox"], candidate["bbox"], tol):
+            return False
+
+    if "endpoints" in target and "endpoints" in candidate:
+        compared += 1
+        if not _endpoints_close(target["endpoints"], candidate["endpoints"], tol):
+            return False
+
+    return compared > 0
+
+
+def signature_summary(signature: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a compact signature summary suitable for diagnostics."""
+
+    keys = (
+        "kind",
+        "surface_type",
+        "curve_type",
+        "center",
+        "midpoint",
+        "normal",
+        "length",
+        "area",
+        "radius",
+        "bbox",
+    )
+    return {key: signature[key] for key in keys if key in signature}
+
+
+def _item_signature(item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    signature = item.get("geometry_signature")
+    return signature if isinstance(signature, dict) else None
+
+
+def _selection_error(
+    *,
+    reason: str,
+    item: Dict[str, Any],
+    kind: str,
+    candidate_count: int,
+    match_count: int,
+) -> ValueError:
+    signature = _item_signature(item) or {}
+    source = item.get("source") if isinstance(item.get("source"), dict) else {}
+    selected_id = item.get("item_id") or item.get("selected_subshape_id") or "<unknown>"
+    method = item.get("original_selection_method") or item.get("selection_method")
+    return ValueError(
+        "selected_subshape geometry match failed: "
+        f"{reason}; source node={source.get('node_id')}; "
+        f"selected_subshape id={selected_id}; kind={kind}; "
+        f"original selection method={method}; "
+        f"signature={signature_summary(signature)}; "
+        f"matches={match_count}; candidates={candidate_count}"
+    )
+
+
+def match_selected_subshape_items(
+    candidates: Sequence[TShape],
+    items: Sequence[Dict[str, Any]],
+    *,
+    kind: str,
+    allow_duplicate_matches: bool = False,
+) -> List[TShape]:
+    """Match ordered selected_subshape items against a candidate list."""
+
+    candidate_signatures = [extract_geometry_signature(candidate) for candidate in candidates]
+    matched: List[TShape] = []
+    used_indices: set[int] = set()
+    normalized_kind = str(kind).lower()
+
+    for item in items:
+        signature = _item_signature(item)
+        if signature is None:
+            raise _selection_error(
+                reason="missing geometry_signature",
+                item=item,
+                kind=normalized_kind,
+                candidate_count=len(candidates),
+                match_count=0,
+            )
+
+        matches = [
+            idx
+            for idx, candidate_signature in enumerate(candidate_signatures)
+            if signatures_match(candidate_signature, signature, kind=normalized_kind)
+        ]
+
+        if not matches:
+            raise _selection_error(
+                reason="no candidate matched the stored geometry signature",
+                item=item,
+                kind=normalized_kind,
+                candidate_count=len(candidates),
+                match_count=0,
+            )
+        if len(matches) > 1:
+            raise _selection_error(
+                reason="ambiguous geometry signature matched multiple candidates",
+                item=item,
+                kind=normalized_kind,
+                candidate_count=len(candidates),
+                match_count=len(matches),
+            )
+
+        idx = matches[0]
+        if idx in used_indices and not allow_duplicate_matches:
+            raise _selection_error(
+                reason="duplicate selection items matched the same candidate",
+                item=item,
+                kind=normalized_kind,
+                candidate_count=len(candidates),
+                match_count=1,
+            )
+        used_indices.add(idx)
+        matched.append(candidates[idx])
+
+    return matched
+
+
+def selected_subshape_items(
+    params: Dict[str, Any],
+    *,
+    kind: Optional[str] = None,
+    role: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    payload = params.get("selected_subshapes")
+    if not isinstance(payload, dict):
+        return []
+    items = payload.get("items")
+    if not isinstance(items, list):
+        return []
+    result: List[Dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if kind is not None and str(item.get("kind", "")).lower() != kind.lower():
+            continue
+        if role is not None and str(item.get("role", "")).lower() != role.lower():
+            continue
+        result.append(item)
+    return result
+

--- a/src/simplecadapi/serializer.py
+++ b/src/simplecadapi/serializer.py
@@ -1033,6 +1033,65 @@ def _resolve_faces_from_selected_subshapes(
     return match_selected_subshape_items(solid.get_faces(), items, kind="face")
 
 
+def _resolve_single_selected_source_shape(
+    owner: Solid,
+    params: Dict[str, Any],
+    *,
+    edge_role: str,
+    face_role: str,
+) -> AnyShape:
+    edge_items = selected_subshape_items(params, kind="edge", role=edge_role)
+    if edge_items:
+        edges = match_selected_subshape_items(owner.get_edges(), edge_items, kind="edge")
+        if str(params.get("selected_source_kind", "")).lower() == "wire":
+            return ops.make_wire_from_edges_rwire(edges)
+        if edges:
+            return edges[0]
+    face_items = selected_subshape_items(params, kind="face", role=face_role)
+    if face_items:
+        faces = match_selected_subshape_items(owner.get_faces(), face_items, kind="face")
+        if faces:
+            return faces[0]
+    return owner
+
+
+def _resolve_edges_from_selection_payload(
+    solid: Solid, payload: Dict[str, Any]
+) -> List[Edge]:
+    items = payload.get("items") if isinstance(payload, dict) else None
+    if not isinstance(items, list):
+        return []
+    return match_selected_subshape_items(solid.get_edges(), items, kind="edge")
+
+
+def _resolve_edges_from_source_items(
+    outputs: Dict[str, List[AnyShape]],
+    payload: Dict[str, Any],
+) -> List[Edge]:
+    items = payload.get("items") if isinstance(payload, dict) else None
+    if not isinstance(items, list):
+        return []
+    edges: List[Edge] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        source = item.get("source")
+        source_node_id = source.get("node_id") if isinstance(source, dict) else None
+        if source_node_id is None:
+            return []
+        owner_outputs = outputs.get(str(source_node_id), [])
+        if not owner_outputs:
+            return []
+        edges.extend(
+            match_selected_subshape_items(
+                cast(Solid, owner_outputs[0]).get_edges(),
+                [item],
+                kind="edge",
+            )
+        )
+    return edges
+
+
 def _execute_graph(
     graph: OperationGraph, leaf_node_ids: Optional[Sequence[str]] = None
 ) -> List[AnyShape]:
@@ -1094,9 +1153,21 @@ def _execute_graph(
                 continue
 
             if op_name == "make_face_from_wire_rface":
-                wire_outputs = (
-                    outputs.get(node.inputs[0].node_id, []) if node.inputs else []
+                wire_outputs: List[AnyShape] = []
+                boundary_items = selected_subshape_items(
+                    params, kind="edge", role="face_boundary_edge"
                 )
+                if boundary_items and node.inputs:
+                    owner_outputs = outputs.get(node.inputs[0].node_id, [])
+                    if owner_outputs:
+                        edges = match_selected_subshape_items(
+                            cast(Solid, owner_outputs[0]).get_edges(),
+                            boundary_items,
+                            kind="edge",
+                        )
+                        wire_outputs.append(ops.make_wire_from_edges_rwire(edges))
+                elif node.inputs:
+                    wire_outputs = outputs.get(node.inputs[0].node_id, [])
                 if wire_outputs:
                     result = ops.make_face_from_wire_rface(
                         cast(Any, wire_outputs[0]),
@@ -1107,8 +1178,17 @@ def _execute_graph(
 
             if op_name == "make_wire_from_edges_rwire":
                 edge_outputs: List[AnyShape] = []
-                for inp in node.inputs:
-                    edge_outputs.extend(outputs.get(inp.node_id, []))
+                edge_items = selected_subshape_items(params, kind="edge", role="wire_edge")
+                if edge_items:
+                    edge_outputs.extend(
+                        _resolve_edges_from_source_items(
+                            outputs,
+                            cast(Dict[str, Any], params.get("selected_subshapes", {})),
+                        )
+                    )
+                else:
+                    for inp in node.inputs:
+                        edge_outputs.extend(outputs.get(inp.node_id, []))
                 if edge_outputs:
                     result = ops.make_wire_from_edges_rwire(cast(Any, edge_outputs))
                     _store_outputs(node, result)
@@ -1119,8 +1199,14 @@ def _execute_graph(
                     outputs.get(node.inputs[0].node_id, []) if node.inputs else []
                 )
                 if input_outputs:
+                    shape = _resolve_single_selected_source_shape(
+                        cast(Solid, input_outputs[0]),
+                        params,
+                        edge_role="translate_source_edge",
+                        face_role="translate_source_face",
+                    )
                     result = ops.translate_shape(
-                        cast(AnyShape, input_outputs[0]),
+                        cast(AnyShape, shape),
                         cast(Any, tuple(params.get("vector", (0, 0, 0)))),
                     )
                     _store_outputs(node, result)
@@ -1131,8 +1217,14 @@ def _execute_graph(
                     outputs.get(node.inputs[0].node_id, []) if node.inputs else []
                 )
                 if input_outputs:
+                    shape = _resolve_single_selected_source_shape(
+                        cast(Solid, input_outputs[0]),
+                        params,
+                        edge_role="rotate_source_edge",
+                        face_role="rotate_source_face",
+                    )
                     result = ops.rotate_shape(
-                        cast(AnyShape, input_outputs[0]),
+                        cast(AnyShape, shape),
                         params.get("angle", 0.0),
                         axis=cast(Any, tuple(params.get("axis", (0, 0, 1)))),
                         origin=cast(Any, tuple(params.get("origin", (0, 0, 0)))),
@@ -1145,8 +1237,19 @@ def _execute_graph(
                     outputs.get(node.inputs[0].node_id, []) if node.inputs else []
                 )
                 if profile_outputs:
+                    profile = profile_outputs[0]
+                    face_items = selected_subshape_items(
+                        params, kind="face", role="extrude_profile_face"
+                    )
+                    if face_items:
+                        matched_faces = match_selected_subshape_items(
+                            cast(Solid, profile).get_faces(),
+                            face_items,
+                            kind="face",
+                        )
+                        profile = matched_faces[0]
                     result = ops.extrude_rsolid(
-                        cast(Any, profile_outputs[0]),
+                        cast(Any, profile),
                         cast(Any, tuple(params.get("direction", (0, 0, 1)))),
                         params.get("distance", 1.0),
                     )
@@ -1158,8 +1261,19 @@ def _execute_graph(
                     outputs.get(node.inputs[0].node_id, []) if node.inputs else []
                 )
                 if profile_outputs:
+                    profile = profile_outputs[0]
+                    face_items = selected_subshape_items(
+                        params, kind="face", role="revolve_profile_face"
+                    )
+                    if face_items:
+                        matched_faces = match_selected_subshape_items(
+                            cast(Solid, profile).get_faces(),
+                            face_items,
+                            kind="face",
+                        )
+                        profile = matched_faces[0]
                     result = ops.revolve_rsolid(
-                        cast(Any, profile_outputs[0]),
+                        cast(Any, profile),
                         axis=cast(Any, tuple(params.get("axis", (0, 0, 1)))),
                         angle=params.get("angle", 360),
                         origin=cast(Any, tuple(params.get("origin", (0, 0, 0)))),
@@ -1169,8 +1283,21 @@ def _execute_graph(
 
             if op_name == "make_loft_rsolid":
                 profile_outputs: List[AnyShape] = []
-                for inp in node.inputs:
-                    profile_outputs.extend(outputs.get(inp.node_id, []))
+                selected_profiles = params.get("selected_profile_subshapes")
+                if isinstance(selected_profiles, list) and node.inputs:
+                    for inp, selection_payload in zip(node.inputs, selected_profiles):
+                        owner_outputs = outputs.get(inp.node_id, [])
+                        if owner_outputs and isinstance(selection_payload, dict):
+                            edges = _resolve_edges_from_selection_payload(
+                                cast(Solid, owner_outputs[0]), selection_payload
+                            )
+                            if edges:
+                                profile_outputs.append(
+                                    ops.make_wire_from_edges_rwire(edges)
+                                )
+                else:
+                    for inp in node.inputs:
+                        profile_outputs.extend(outputs.get(inp.node_id, []))
                 if profile_outputs:
                     result = ops.loft_rsolid(
                         cast(Any, profile_outputs), ruled=params.get("ruled", False)
@@ -1182,6 +1309,14 @@ def _execute_graph(
                 if len(node.inputs) >= 2:
                     profile_outputs = outputs.get(node.inputs[0].node_id, [])
                     path_outputs = outputs.get(node.inputs[1].node_id, [])
+                    path_payload = params.get("selected_path_subshapes")
+                    if isinstance(path_payload, dict) and path_outputs:
+                        edges = _resolve_edges_from_selection_payload(
+                            cast(Solid, path_outputs[0]), path_payload
+                        )
+                        path_outputs = [
+                            ops.make_wire_from_edges_rwire(edges)
+                        ] if edges else []
                     if profile_outputs and path_outputs:
                         profile = profile_outputs[0]
                         face_items = selected_subshape_items(
@@ -1207,8 +1342,14 @@ def _execute_graph(
                     outputs.get(node.inputs[0].node_id, []) if node.inputs else []
                 )
                 if input_outputs:
+                    shape = _resolve_single_selected_source_shape(
+                        cast(Solid, input_outputs[0]),
+                        params,
+                        edge_role="mirror_source_edge",
+                        face_role="mirror_source_face",
+                    )
                     result = ops.mirror_shape(
-                        cast(Any, input_outputs[0]),
+                        cast(Any, shape),
                         cast(Any, tuple(params.get("plane_origin", (0, 0, 0)))),
                         cast(Any, tuple(params.get("plane_normal", (0, 0, 1)))),
                     )

--- a/src/simplecadapi/serializer.py
+++ b/src/simplecadapi/serializer.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import math
 
 from typing import Any, Dict, List, Optional, Sequence, Tuple, cast
+import warnings
 
 from .errors import raise_harness_error
 
@@ -37,6 +38,7 @@ from .topology import (
     topo_ref_from_dict,
 )
 from . import operations as ops
+from .selection_signature import match_selected_subshape_items, selected_subshape_items
 
 
 PUBLIC_API_COVERAGE: Dict[str, Dict[str, str]] = {
@@ -195,6 +197,7 @@ CANONICAL_CORE_OP_SET: Tuple[str, ...] = (
 )
 
 SELECTION_REF_SCHEMA: Dict[str, Any] = {
+    "selection_param": "selected_subshapes",
     "edge_param": "selected_edges",
     "face_param": "selected_faces",
     "edge_index_param": "selected_edge_indices",
@@ -206,12 +209,21 @@ SELECTION_REF_SCHEMA: Dict[str, Any] = {
         "kind",
         "topo_id",
     ],
-    "optional_fields": ["selector_hint"],
+    "required_item_fields": [
+        "item_id",
+        "kind",
+        "source",
+        "geometry_signature",
+        "original_selection_method",
+        "order",
+    ],
+    "optional_fields": ["selector_hint", "selection_query_debug"],
     "replay_resolution_order": [
+        "geometry_signature",
         "explicit_topo_refs",
-        "stable_indices",
-        "selection_query",
-        "selector_hint",
+        "legacy_index_fallback",
+        "legacy_selection_query",
+        "legacy_selector_hint",
     ],
 }
 
@@ -228,6 +240,7 @@ def _canonical_contract_payload() -> Dict[str, Any]:
         },
         "core_op_set": list(CANONICAL_CORE_OP_SET),
         "selection_ref_schema": {
+            "selection_param": SELECTION_REF_SCHEMA["selection_param"],
             "edge_param": SELECTION_REF_SCHEMA["edge_param"],
             "face_param": SELECTION_REF_SCHEMA["face_param"],
             "edge_index_param": SELECTION_REF_SCHEMA["edge_index_param"],
@@ -236,6 +249,7 @@ def _canonical_contract_payload() -> Dict[str, Any]:
                 SELECTION_REF_SCHEMA["required_topo_ref_fields"]
             ),
             "optional_fields": list(SELECTION_REF_SCHEMA["optional_fields"]),
+            "required_item_fields": list(SELECTION_REF_SCHEMA["required_item_fields"]),
             "replay_resolution_order": list(
                 SELECTION_REF_SCHEMA["replay_resolution_order"]
             ),
@@ -988,6 +1002,37 @@ def _resolve_faces_from_indices(solid: Solid, indices: Sequence[int]) -> List[Fa
     return [faces[idx] for idx in indices if 0 <= idx < len(faces)]
 
 
+def _warn_legacy_index_fallback(op_name: str) -> None:
+    warnings.warn(
+        f"{op_name} replay is using legacy selected_*_indices fallback because the graph has no selected_subshapes geometry signatures. "
+        "New graphs should store geometry signatures and should not rely on SimpleCAD/OCP index order.",
+        RuntimeWarning,
+        stacklevel=3,
+    )
+
+
+def _resolve_edges_from_selected_subshapes(
+    solid: Solid, params: Dict[str, Any], *, role: str
+) -> List[Edge]:
+    items = selected_subshape_items(params, kind="edge", role=role)
+    if not items:
+        items = selected_subshape_items(params, kind="edge")
+    if not items:
+        return []
+    return match_selected_subshape_items(solid.get_edges(), items, kind="edge")
+
+
+def _resolve_faces_from_selected_subshapes(
+    solid: Solid, params: Dict[str, Any], *, role: str
+) -> List[Face]:
+    items = selected_subshape_items(params, kind="face", role=role)
+    if not items:
+        items = selected_subshape_items(params, kind="face")
+    if not items:
+        return []
+    return match_selected_subshape_items(solid.get_faces(), items, kind="face")
+
+
 def _execute_graph(
     graph: OperationGraph, leaf_node_ids: Optional[Sequence[str]] = None
 ) -> List[AnyShape]:
@@ -1138,8 +1183,19 @@ def _execute_graph(
                     profile_outputs = outputs.get(node.inputs[0].node_id, [])
                     path_outputs = outputs.get(node.inputs[1].node_id, [])
                     if profile_outputs and path_outputs:
+                        profile = profile_outputs[0]
+                        face_items = selected_subshape_items(
+                            params, kind="face", role="sweep_profile_face"
+                        )
+                        if face_items:
+                            matched_faces = match_selected_subshape_items(
+                                cast(Solid, profile).get_faces(),
+                                face_items,
+                                kind="face",
+                            )
+                            profile = matched_faces[0]
                         result = ops.sweep_rsolid(
-                            cast(Any, profile_outputs[0]),
+                            cast(Any, profile),
                             cast(Any, path_outputs[0]),
                             is_frenet=bool(params.get("is_frenet", False)),
                         )
@@ -1165,31 +1221,35 @@ def _execute_graph(
                 )
                 if input_outputs:
                     solid = cast(Solid, input_outputs[0])
-                    selected_edges = cast(
-                        Sequence[Dict[str, Any]], params.get("selected_edges", [])
+                    edges = _resolve_edges_from_selected_subshapes(
+                        solid, params, role="fillet_edge"
                     )
-                    edges: List[Edge] = []
-                    edges = _resolve_edges_from_refs(solid, selected_edges)
-                    if len(edges) != len(selected_edges):
-                        edges = _resolve_edges_from_indices(
-                            solid,
-                            cast(
-                                Sequence[int],
-                                params.get("selected_edge_indices", []),
-                            ),
+                    if not edges:
+                        selected_edges = cast(
+                            Sequence[Dict[str, Any]], params.get("selected_edges", [])
                         )
-                    selection_query = params.get("selection_query")
-                    if len(edges) != len(selected_edges) and isinstance(
-                        selection_query, dict
-                    ):
-                        edges = cast(
-                            List[Edge],
-                            selector_from_dict(selection_query).resolve(solid),
-                        )
-                    if len(edges) != len(selected_edges):
-                        edges = _resolve_edges_from_selector_hints(
-                            solid, selected_edges
-                        )
+                        edges = _resolve_edges_from_refs(solid, selected_edges)
+                        if len(edges) != len(selected_edges):
+                            _warn_legacy_index_fallback(op_name)
+                            edges = _resolve_edges_from_indices(
+                                solid,
+                                cast(
+                                    Sequence[int],
+                                    params.get("selected_edge_indices", []),
+                                ),
+                            )
+                        selection_query = params.get("selection_query")
+                        if len(edges) != len(selected_edges) and isinstance(
+                            selection_query, dict
+                        ):
+                            edges = cast(
+                                List[Edge],
+                                selector_from_dict(selection_query).resolve(solid),
+                            )
+                        if len(edges) != len(selected_edges):
+                            edges = _resolve_edges_from_selector_hints(
+                                solid, selected_edges
+                            )
                     result = ops.fillet_rsolid(
                         solid,
                         edges,
@@ -1204,31 +1264,35 @@ def _execute_graph(
                 )
                 if input_outputs:
                     solid = cast(Solid, input_outputs[0])
-                    selected_edges = cast(
-                        Sequence[Dict[str, Any]], params.get("selected_edges", [])
+                    edges = _resolve_edges_from_selected_subshapes(
+                        solid, params, role="chamfer_edge"
                     )
-                    edges: List[Edge] = []
-                    edges = _resolve_edges_from_refs(solid, selected_edges)
-                    if len(edges) != len(selected_edges):
-                        edges = _resolve_edges_from_indices(
-                            solid,
-                            cast(
-                                Sequence[int],
-                                params.get("selected_edge_indices", []),
-                            ),
+                    if not edges:
+                        selected_edges = cast(
+                            Sequence[Dict[str, Any]], params.get("selected_edges", [])
                         )
-                    selection_query = params.get("selection_query")
-                    if len(edges) != len(selected_edges) and isinstance(
-                        selection_query, dict
-                    ):
-                        edges = cast(
-                            List[Edge],
-                            selector_from_dict(selection_query).resolve(solid),
-                        )
-                    if len(edges) != len(selected_edges):
-                        edges = _resolve_edges_from_selector_hints(
-                            solid, selected_edges
-                        )
+                        edges = _resolve_edges_from_refs(solid, selected_edges)
+                        if len(edges) != len(selected_edges):
+                            _warn_legacy_index_fallback(op_name)
+                            edges = _resolve_edges_from_indices(
+                                solid,
+                                cast(
+                                    Sequence[int],
+                                    params.get("selected_edge_indices", []),
+                                ),
+                            )
+                        selection_query = params.get("selection_query")
+                        if len(edges) != len(selected_edges) and isinstance(
+                            selection_query, dict
+                        ):
+                            edges = cast(
+                                List[Edge],
+                                selector_from_dict(selection_query).resolve(solid),
+                            )
+                        if len(edges) != len(selected_edges):
+                            edges = _resolve_edges_from_selector_hints(
+                                solid, selected_edges
+                            )
                     result = ops.chamfer_rsolid(
                         solid,
                         edges,
@@ -1243,31 +1307,35 @@ def _execute_graph(
                 )
                 if input_outputs:
                     solid = cast(Solid, input_outputs[0])
-                    selected_faces = cast(
-                        Sequence[Dict[str, Any]], params.get("selected_faces", [])
+                    faces = _resolve_faces_from_selected_subshapes(
+                        solid, params, role="shell_remove_face"
                     )
-                    faces: List[Face] = []
-                    faces = _resolve_faces_from_refs(solid, selected_faces)
-                    if len(faces) != len(selected_faces):
-                        faces = _resolve_faces_from_indices(
-                            solid,
-                            cast(
-                                Sequence[int],
-                                params.get("selected_face_indices", []),
-                            ),
+                    if not faces:
+                        selected_faces = cast(
+                            Sequence[Dict[str, Any]], params.get("selected_faces", [])
                         )
-                    selection_query = params.get("selection_query")
-                    if len(faces) != len(selected_faces) and isinstance(
-                        selection_query, dict
-                    ):
-                        faces = cast(
-                            List[Face],
-                            selector_from_dict(selection_query).resolve(solid),
-                        )
-                    if len(faces) != len(selected_faces):
-                        faces = _resolve_faces_from_selector_hints(
-                            solid, selected_faces
-                        )
+                        faces = _resolve_faces_from_refs(solid, selected_faces)
+                        if len(faces) != len(selected_faces):
+                            _warn_legacy_index_fallback(op_name)
+                            faces = _resolve_faces_from_indices(
+                                solid,
+                                cast(
+                                    Sequence[int],
+                                    params.get("selected_face_indices", []),
+                                ),
+                            )
+                        selection_query = params.get("selection_query")
+                        if len(faces) != len(selected_faces) and isinstance(
+                            selection_query, dict
+                        ):
+                            faces = cast(
+                                List[Face],
+                                selector_from_dict(selection_query).resolve(solid),
+                            )
+                        if len(faces) != len(selected_faces):
+                            faces = _resolve_faces_from_selector_hints(
+                                solid, selected_faces
+                            )
                     result = ops.shell_rsolid(
                         solid,
                         faces,
@@ -1282,25 +1350,27 @@ def _execute_graph(
                 try:
                     result = factory(params)
                     _store_outputs(node, result)
+                except ValueError:
+                    raise
                 except Exception as exc:
-                    raise ValueError(
-                        f"Failed to replay graph node '{node.node_id}' ({op_name}): {exc}"
+                    raise RuntimeError(
+                        f"Failed to replay node {node.node_id} ({op_name})"
                     ) from exc
-            else:
-                raise ValueError(
-                    f"No replay handler registered for graph node '{node.node_id}' ({op_name})"
-                )
+                continue
 
-    leaf_results: List[AnyShape] = []
-    if leaf_node_ids is None:
-        target_leaf_ids = [leaf.node_id for leaf in graph.leaf_nodes()]
-    else:
-        target_leaf_ids = [str(node_id) for node_id in leaf_node_ids]
-    for node_id in target_leaf_ids:
-        leaf_results.extend(outputs.get(node_id, []))
+            raise ValueError(f"Unsupported operation for replay: {op_name}")
 
-    return leaf_results
+    if leaf_node_ids:
+        selected: List[AnyShape] = []
+        for node_id in leaf_node_ids:
+            selected.extend(outputs.get(str(node_id), []))
+        return selected
 
+    leaves = graph.leaf_nodes()
+    result: List[AnyShape] = []
+    for leaf in leaves:
+        result.extend(outputs.get(leaf.node_id, []))
+    return result
 
 def replay_graph(graph: OperationGraph) -> List[AnyShape]:
     """Replay an OperationGraph to rebuild the model.

--- a/src/simplecadapi/topology.py
+++ b/src/simplecadapi/topology.py
@@ -29,6 +29,7 @@ def _producer_version() -> str:
 def graph_capabilities_payload() -> Dict[str, Any]:
     return {
         "selection_ref_strategies": True,
+        "selected_subshape_signatures": True,
         "selector_hint_fallback": True,
         "display_payload": True,
         "topology_delta_summary": False,
@@ -409,6 +410,7 @@ def _node_display_summary(op: str, params: Dict[str, Any]) -> str:
         "selected_faces",
         "selected_edge_indices",
         "selected_face_indices",
+        "selected_subshapes",
     }
     summary_parts: List[str] = []
     for key, value in params.items():
@@ -430,7 +432,12 @@ def _node_display_summary(op: str, params: Dict[str, Any]) -> str:
 
 def _node_display_payload(op: str, params: Dict[str, Any]) -> Dict[str, Any]:
     selection_count = 0
-    if isinstance(params.get("selected_edges"), list):
+    selected_subshapes = params.get("selected_subshapes")
+    if isinstance(selected_subshapes, dict) and isinstance(
+        selected_subshapes.get("items"), list
+    ):
+        selection_count = len(selected_subshapes["items"])
+    elif isinstance(params.get("selected_edges"), list):
         selection_count = len(params["selected_edges"])
     elif isinstance(params.get("selected_faces"), list):
         selection_count = len(params["selected_faces"])

--- a/test/test_freecad_translator.py
+++ b/test/test_freecad_translator.py
@@ -360,7 +360,8 @@ with open(OUT_PATH, 'w', encoding='utf-8') as fh:
         script = scad.translate_model_json_to_freecad_script(json.dumps(payload_obj))
 
         self.assertIn("Part::Sweep", script)
-        self.assertIn(".Spine = GRAPH_NODES", script)
+        self.assertIn("_path_feature", script)
+        self.assertIn(".Spine =", script)
         self.assertIn(".Frenet = bool(", script)
         self.assertIn("'Frenet'", script)
 
@@ -401,6 +402,221 @@ with open(OUT_PATH, 'w', encoding='utf-8') as fh:
         self.assertIn("_match_subshape_indices", script)
         self.assertIn("sweep_profile_face", script)
         self.assertIn("_profile_feature.Shape", script)
+
+    def test_existing_solid_face_extrude_records_profile_signature(self):
+        with GraphSession() as session:
+            profile = scad.make_circle_rface((0.0, 0.0, 0.0), 1.0)
+            base = scad.extrude_rsolid(profile, (0.0, 0.0, 1.0), 2.0)
+            top_face = (
+                scad.ql.faces()
+                .where(scad.ql.prop("geom.normal.z", ">", 0.9))
+                .take(1)
+                .exactly(1)
+                .resolve(base)[0]
+            )
+            scad.extrude_rsolid(top_face, (0.0, 0.0, 1.0), 1.0)
+
+        payload = json.loads(scad.export_model_json(session))
+        extrude_nodes = [
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_extrude_rsolid"
+        ]
+        selected_extrude = extrude_nodes[-1]
+        selected = selected_extrude["params"]["selected_subshapes"]
+        item = selected["items"][0]
+
+        self.assertEqual(selected_extrude["inputs"], [extrude_nodes[0]["node_id"]])
+        self.assertEqual(selected["role"], "extrude_profile_face")
+        self.assertEqual(item["kind"], "face")
+        self.assertEqual(item["original_selection_method"], "ql")
+        self.assertIn("geometry_signature", item)
+
+        script = scad.translate_model_json_to_freecad_script(json.dumps(payload))
+        self.assertIn("'extrude_profile_face'", script)
+        self.assertIn("_selected_subshape_features", script)
+        self.assertIn(".Base =", script)
+
+    def test_existing_solid_face_revolve_records_profile_signature(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(2.0, 3.0, 4.0)
+            face = box.get_faces()[0]
+            scad.revolve_rsolid(face, axis=(0.0, 1.0, 0.0), angle=90.0)
+
+        payload = json.loads(scad.export_model_json(session))
+        revolve_node = next(
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_revolve_rsolid"
+        )
+        selected = revolve_node["params"]["selected_subshapes"]
+
+        self.assertEqual(selected["role"], "revolve_profile_face")
+        self.assertEqual(selected["items"][0]["kind"], "face")
+        self.assertIn("geometry_signature", selected["items"][0])
+
+        script = scad.translate_model_json_to_freecad_script(json.dumps(payload))
+        self.assertIn("'revolve_profile_face'", script)
+        self.assertIn(".Source =", script)
+
+    def test_existing_solid_edge_wire_records_edge_signatures(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(3.0, 4.0, 5.0)
+            scad.make_wire_from_edges_rwire([box.get_edges()[0]])
+
+        payload = json.loads(scad.export_model_json(session))
+        wire_nodes = [
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_wire_from_edges_rwire"
+        ]
+        selected_wire = wire_nodes[-1]
+        selected = selected_wire["params"]["selected_subshapes"]
+
+        self.assertEqual(selected["role"], "wire_edge")
+        self.assertEqual(selected["item_count"], 1)
+        self.assertEqual(selected["items"][0]["kind"], "edge")
+        self.assertIn("geometry_signature", selected["items"][0])
+        self.assertEqual(len(selected_wire["inputs"]), 1)
+
+        script = scad.translate_model_json_to_freecad_script(json.dumps(payload))
+        self.assertIn("'wire_edge'", script)
+        self.assertIn("_selected_edge_wire_feature_from_sources", script)
+
+    def test_face_from_existing_solid_wire_records_boundary_signatures(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(3.0, 4.0, 5.0)
+            top_face = max(box.get_faces(), key=lambda face: face.get_center().z)
+            boundary = top_face.get_outer_wire()
+            scad.make_face_from_wire_rface(boundary, normal=(0.0, 0.0, 1.0))
+
+        payload = json.loads(scad.export_model_json(session))
+        face_nodes = [
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_face_from_wire_rface"
+        ]
+        selected_face_node = face_nodes[-1]
+        selected = selected_face_node["params"]["selected_subshapes"]
+
+        self.assertEqual(selected["role"], "face_boundary_edge")
+        self.assertEqual(selected["item_count"], 4)
+        self.assertEqual([item["order"] for item in selected["items"]], [0, 1, 2, 3])
+        self.assertTrue(all(item["kind"] == "edge" for item in selected["items"]))
+
+        script = scad.translate_model_json_to_freecad_script(json.dumps(payload))
+        self.assertIn("'face_boundary_edge'", script)
+        self.assertIn("_selected_edge_wire_feature", script)
+
+    def test_loft_from_existing_solid_wires_records_profile_signatures(self):
+        with GraphSession() as session:
+            lower = scad.make_box_rsolid(3.0, 3.0, 1.0)
+            upper = scad.translate_shape(scad.make_box_rsolid(2.0, 2.0, 1.0), (0, 0, 3))
+            lower_top = max(lower.get_faces(), key=lambda face: face.get_center().z)
+            upper_top = max(upper.get_faces(), key=lambda face: face.get_center().z)
+            scad.loft_rsolid(
+                [lower_top.get_outer_wire(), upper_top.get_outer_wire()],
+                ruled=True,
+            )
+
+        payload = json.loads(scad.export_model_json(session))
+        loft_node = next(
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_loft_rsolid"
+        )
+        selected_profiles = loft_node["params"]["selected_profile_subshapes"]
+
+        self.assertEqual(len(selected_profiles), 2)
+        self.assertEqual(
+            [payload["role"] for payload in selected_profiles],
+            ["loft_profile_0_edge", "loft_profile_1_edge"],
+        )
+        self.assertTrue(
+            all(
+                item["kind"] == "edge"
+                for payload in selected_profiles
+                for item in payload["items"]
+            )
+        )
+
+        script = scad.translate_model_json_to_freecad_script(json.dumps(payload))
+        self.assertIn("selected_profile_subshapes", script)
+        self.assertIn("_selected_edge_wire_feature", script)
+
+    def test_transform_existing_solid_face_records_source_signature(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(2.0, 3.0, 4.0)
+            top_face = max(box.get_faces(), key=lambda face: face.get_center().z)
+            scad.translate_shape(top_face, (1.0, 0.0, 0.0))
+
+        payload = json.loads(scad.export_model_json(session))
+        translate_node = next(
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_translate_rshape"
+        )
+        selected = translate_node["params"]["selected_subshapes"]
+        item = selected["items"][0]
+
+        self.assertEqual(selected["role"], "translate_source_face")
+        self.assertEqual(translate_node["params"]["selected_source_kind"], "face")
+        self.assertEqual(item["kind"], "face")
+        self.assertIn("geometry_signature", item)
+
+        script = scad.translate_model_json_to_freecad_script(json.dumps(payload))
+        self.assertIn("_selected_source_feature", script)
+        self.assertIn("'translate_source_face'", script)
+
+    def test_transform_existing_solid_edge_records_source_signature(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(2.0, 3.0, 4.0)
+            scad.rotate_shape(box.get_edges()[1], 45.0, axis=(0.0, 0.0, 1.0))
+
+        payload = json.loads(scad.export_model_json(session))
+        rotate_node = next(
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_rotate_rshape"
+        )
+        selected = rotate_node["params"]["selected_subshapes"]
+        item = selected["items"][0]
+
+        self.assertEqual(selected["role"], "rotate_source_edge")
+        self.assertEqual(rotate_node["params"]["selected_source_kind"], "edge")
+        self.assertEqual(item["kind"], "edge")
+        self.assertIn("geometry_signature", item)
+
+        script = scad.translate_model_json_to_freecad_script(json.dumps(payload))
+        self.assertIn("_selected_source_feature", script)
+        self.assertIn("'rotate_source_edge'", script)
+
+    def test_transform_existing_solid_wire_records_source_edge_signatures(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(2.0, 3.0, 4.0)
+            top_face = max(box.get_faces(), key=lambda face: face.get_center().z)
+            scad.mirror_shape(
+                top_face.get_outer_wire(),
+                (0.0, 0.0, 0.0),
+                (1.0, 0.0, 0.0),
+            )
+
+        payload = json.loads(scad.export_model_json(session))
+        mirror_node = next(
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_mirror_rshape"
+        )
+        selected = mirror_node["params"]["selected_subshapes"]
+
+        self.assertEqual(selected["role"], "mirror_source_edge")
+        self.assertEqual(mirror_node["params"]["selected_source_kind"], "wire")
+        self.assertEqual(selected["item_count"], 4)
+        self.assertTrue(all(item["kind"] == "edge" for item in selected["items"]))
+
+        script = scad.translate_model_json_to_freecad_script(json.dumps(payload))
+        self.assertIn("_selected_source_feature", script)
+        self.assertIn("'mirror_source_edge'", script)
 
     def test_index_edge_selection_for_fillet_records_ordered_signatures(self):
         with GraphSession() as session:
@@ -690,6 +906,145 @@ with open(OUT_PATH, 'w', encoding='utf-8') as fh:
         self.assertEqual(
             [round(v, 6) for v in result["faces"][0][1:]],
             [round(v, 6) for v in result["target_center"]],
+        )
+
+    def test_freecad_extrudes_existing_solid_face_by_signature(self):
+        with GraphSession() as session:
+            profile = scad.make_circle_rface((0.0, 0.0, 0.0), 1.0)
+            base = scad.extrude_rsolid(profile, (0.0, 0.0, 1.0), 2.0)
+            top_face = (
+                scad.ql.faces()
+                .where(scad.ql.prop("geom.normal.z", ">", 0.9))
+                .take(1)
+                .exactly(1)
+                .resolve(base)[0]
+            )
+            expected_center = top_face.get_center()
+            scad.extrude_rsolid(top_face, (0.0, 0.0, 1.0), 1.0)
+
+        payload_text = scad.export_model_json(session)
+        probe = f"""
+import json
+import FreeCAD as App
+
+doc = App.openDocument(FCSTD_PATH)
+extrudes = [obj for obj in doc.Objects if getattr(obj, 'SimpleCADOp', '') == 'make_extrude_rsolid']
+target = extrudes[-1]
+base = target.Base.Shape
+center = base.CenterOfMass
+with open(OUT_PATH, 'w', encoding='utf-8') as fh:
+    json.dump({{
+        'extrude_count': len(extrudes),
+        'target_base_type': base.ShapeType,
+        'target_base_center': [float(center.x), float(center.y), float(center.z)],
+        'expected_center': [{float(expected_center.x)}, {float(expected_center.y)}, {float(expected_center.z)}],
+        'is_null': target.Shape.isNull(),
+    }}, fh)
+"""
+        result = self._inspect_fcstd_json(payload_text, probe)
+        self.assertEqual(result["extrude_count"], 2)
+        self.assertEqual(result["target_base_type"], "Face")
+        self.assertFalse(result["is_null"])
+        self.assertEqual(
+            [round(v, 6) for v in result["target_base_center"]],
+            [round(v, 6) for v in result["expected_center"]],
+        )
+
+    def test_freecad_wire_from_existing_solid_edge_matches_signature(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(2.0, 3.0, 4.0)
+            selected_edge = box.get_edges()[2]
+            expected_center = selected_edge.get_center()
+            scad.make_wire_from_edges_rwire([selected_edge])
+
+        payload_text = scad.export_model_json(session)
+        probe = f"""
+import json
+import FreeCAD as App
+
+doc = App.openDocument(FCSTD_PATH)
+wires = [obj for obj in doc.Objects if getattr(obj, 'SimpleCADOp', '') == 'make_wire_from_edges_rwire']
+target = wires[-1]
+edge = target.Shape.Edges[0]
+center = edge.CenterOfMass
+with open(OUT_PATH, 'w', encoding='utf-8') as fh:
+    json.dump({{
+        'wire_edge_count': len(target.Shape.Edges),
+        'wire_center': [float(center.x), float(center.y), float(center.z)],
+        'expected_center': [{float(expected_center.x)}, {float(expected_center.y)}, {float(expected_center.z)}],
+    }}, fh)
+"""
+        result = self._inspect_fcstd_json(payload_text, probe)
+        self.assertEqual(result["wire_edge_count"], 1)
+        self.assertEqual(
+            [round(v, 6) for v in result["wire_center"]],
+            [round(v, 6) for v in result["expected_center"]],
+        )
+
+    def test_freecad_face_from_existing_solid_wire_matches_boundary_signatures(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(2.0, 3.0, 4.0)
+            top_face = max(box.get_faces(), key=lambda face: face.get_center().z)
+            expected_area = top_face.get_area()
+            face = scad.make_face_from_wire_rface(
+                top_face.get_outer_wire(), normal=(0.0, 0.0, 1.0)
+            )
+            scad.extrude_rsolid(face, (0.0, 0.0, 1.0), 1.0)
+
+        payload_text = scad.export_model_json(session)
+        probe = f"""
+import json
+import FreeCAD as App
+
+doc = App.openDocument(FCSTD_PATH)
+faces = [obj for obj in doc.Objects if getattr(obj, 'SimpleCADOp', '') == 'make_face_from_wire_rface']
+target = faces[-1]
+with open(OUT_PATH, 'w', encoding='utf-8') as fh:
+    json.dump({{
+        'shape_type': target.Shape.ShapeType,
+        'area': float(target.Shape.Area),
+        'expected_area': {float(expected_area)},
+        'edge_count': len(target.Shape.Edges),
+    }}, fh)
+"""
+        result = self._inspect_fcstd_json(payload_text, probe)
+        self.assertEqual(result["shape_type"], "Face")
+        self.assertEqual(result["edge_count"], 4)
+        self.assertAlmostEqual(result["area"], result["expected_area"], places=5)
+
+    def test_freecad_sweep_path_from_existing_solid_edge_matches_signature(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(2.0, 3.0, 4.0)
+            selected_edge = box.get_edges()[2]
+            expected_center = selected_edge.get_center()
+            path = scad.make_wire_from_edges_rwire([selected_edge])
+            profile = scad.make_circle_rface((0.0, 0.0, 0.0), 0.2)
+            scad.sweep_rsolid(profile, path)
+
+        payload_text = scad.export_model_json(session)
+        probe = f"""
+import json
+import FreeCAD as App
+
+doc = App.openDocument(FCSTD_PATH)
+sweep = [obj for obj in doc.Objects if getattr(obj, 'SimpleCADOp', '') == 'make_sweep_rsolid'][-1]
+spine = sweep.Spine[0] if isinstance(sweep.Spine, tuple) else sweep.Spine
+edge = spine.Shape.Edges[0]
+center = edge.CenterOfMass
+with open(OUT_PATH, 'w', encoding='utf-8') as fh:
+    json.dump({{
+        'spine_edge_count': len(spine.Shape.Edges),
+        'spine_center': [float(center.x), float(center.y), float(center.z)],
+        'expected_center': [{float(expected_center.x)}, {float(expected_center.y)}, {float(expected_center.z)}],
+        'is_null': sweep.Shape.isNull(),
+    }}, fh)
+"""
+        result = self._inspect_fcstd_json(payload_text, probe)
+        self.assertEqual(result["spine_edge_count"], 1)
+        self.assertFalse(result["is_null"])
+        self.assertEqual(
+            [round(v, 6) for v in result["spine_center"]],
+            [round(v, 6) for v in result["expected_center"]],
         )
 
     def test_freecad_ambiguous_signature_raises_instead_of_taking_first(self):

--- a/test/test_freecad_translator.py
+++ b/test/test_freecad_translator.py
@@ -364,6 +364,107 @@ with open(OUT_PATH, 'w', encoding='utf-8') as fh:
         self.assertIn(".Frenet = bool(", script)
         self.assertIn("'Frenet'", script)
 
+    def test_ql_selected_extrusion_face_sweep_records_signature(self):
+        with GraphSession() as session:
+            profile = scad.make_circle_rface((0.0, 0.0, 0.0), 1.0)
+            solid = scad.extrude_rsolid(profile, (0.0, 0.0, 1.0), 2.0)
+            top_face = (
+                scad.ql.faces()
+                .where(scad.ql.prop("geom.normal.z", ">", 0.9))
+                .take(1)
+                .exactly(1)
+                .resolve(solid)[0]
+            )
+            path_edge = scad.make_line_redge((0.0, 0.0, 2.0), (0.0, 0.0, 4.0))
+            path = scad.make_wire_from_edges_rwire([path_edge])
+            scad.sweep_rsolid(top_face, path)
+
+        payload = json.loads(scad.export_model_json(session))
+        sweep_node = next(
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_sweep_rsolid"
+        )
+        selected = sweep_node["params"]["selected_subshapes"]
+        item = selected["items"][0]
+
+        self.assertEqual(selected["item_count"], 1)
+        self.assertEqual(item["kind"], "face")
+        self.assertEqual(item["role"], "sweep_profile_face")
+        self.assertEqual(item["original_selection_method"], "ql")
+        self.assertEqual(item["order"], 0)
+        self.assertIn("geometry_signature", item)
+        self.assertEqual(item["geometry_signature"]["kind"], "face")
+        self.assertEqual(item["geometry_signature"]["surface_type"], "plane")
+
+        script = scad.translate_model_json_to_freecad_script(json.dumps(payload))
+        self.assertIn("_match_subshape_indices", script)
+        self.assertIn("sweep_profile_face", script)
+        self.assertIn("_profile_feature.Shape", script)
+
+    def test_index_edge_selection_for_fillet_records_ordered_signatures(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(3.0, 4.0, 5.0)
+            scad.fillet_rsolid(box, box.get_edges()[:2], 0.2)
+
+        payload = json.loads(scad.export_model_json(session))
+        fillet_node = next(
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_fillet_rsolid"
+        )
+        selected = fillet_node["params"]["selected_subshapes"]
+        items = selected["items"]
+
+        self.assertEqual(selected["item_count"], 2)
+        self.assertEqual([item["order"] for item in items], [0, 1])
+        self.assertEqual(
+            [item["original_selection_method"] for item in items], ["index", "index"]
+        )
+        self.assertTrue(all("geometry_signature" in item for item in items))
+        self.assertTrue(all(item["kind"] == "edge" for item in items))
+
+        script = scad.translate_model_json_to_freecad_script(json.dumps(payload))
+        self.assertIn("_match_subshape_indices", script)
+        self.assertIn("'fillet_edge'", script)
+        self.assertIn("_legacy_edge_indices", script)
+        self.assertNotIn(
+            ".Edges = [(int(idx) + 1",
+            script,
+        )
+
+    def test_index_face_selection_for_shell_records_ordered_signatures(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(3.0, 4.0, 5.0)
+            scad.shell_rsolid(box, box.get_faces()[1:3], 0.1)
+
+        payload = json.loads(scad.export_model_json(session))
+        shell_node = next(
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_shell_rsolid"
+        )
+        selected = shell_node["params"]["selected_subshapes"]
+        items = selected["items"]
+
+        self.assertEqual(selected["item_count"], 2)
+        self.assertEqual([item["order"] for item in items], [0, 1])
+        self.assertTrue(all(item["kind"] == "face" for item in items))
+        self.assertTrue(all("geometry_signature" in item for item in items))
+        self.assertEqual(items[0]["original_index"], 1)
+        self.assertEqual(items[1]["original_index"], 2)
+
+        script = scad.translate_model_json_to_freecad_script(json.dumps(payload))
+        self.assertIn("_match_subshape_indices", script)
+        self.assertIn("'shell_remove_face'", script)
+        self.assertIn("_legacy_face_names", script)
+        face_assignment = next(
+            line for line in script.splitlines() if ".Faces = (GRAPH_NODES" in line
+        )
+        self.assertIn("node_", face_assignment)
+        self.assertIn("face_indices", face_assignment)
+        self.assertNotIn("selected_face_indices", face_assignment)
+
     def test_translate_model_json_uses_single_result_union_helper(self):
         graph = OperationGraph(graph_id="graph_union_single")
         a = graph.add_node(
@@ -507,6 +608,127 @@ with open(OUT_PATH, 'w', encoding='utf-8') as fh:
         self.assertTrue(result["wire_closed"])
         self.assertTrue(result["wire_valid"])
         self.assertTrue(result["face_valid"])
+
+    def test_freecad_matches_index_selected_edge_by_signature_not_index(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(2.0, 3.0, 4.0)
+            selected_edge = box.get_edges()[2]
+            expected_signature = selected_edge.get_center()
+            scad.fillet_rsolid(box, [selected_edge], 0.1)
+
+        payload = json.loads(scad.export_model_json(session))
+        fillet_node = next(
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_fillet_rsolid"
+        )
+        fillet_node["params"]["selected_edge_indices"] = [0]
+        payload_text = json.dumps(payload)
+        probe = f"""
+import json
+import FreeCAD as App
+
+doc = App.openDocument(FCSTD_PATH)
+fillet = [obj for obj in doc.Objects if getattr(obj, 'SimpleCADOp', '') == 'make_fillet_rsolid'][-1]
+base = fillet.Base.Shape
+target_center = ({float(expected_signature.x)}, {float(expected_signature.y)}, {float(expected_signature.z)})
+matched = []
+for edge_id, radius1, radius2 in fillet.Edges:
+    edge = base.Edges[int(edge_id) - 1]
+    center = edge.CenterOfMass
+    matched.append([int(edge_id), float(center.x), float(center.y), float(center.z)])
+with open(OUT_PATH, 'w', encoding='utf-8') as fh:
+    json.dump({{
+        'edges': matched,
+        'target_center': target_center,
+    }}, fh)
+"""
+        result = self._inspect_fcstd_json(payload_text, probe)
+        self.assertEqual(len(result["edges"]), 1)
+        self.assertEqual(
+            [round(v, 6) for v in result["edges"][0][1:]],
+            [round(v, 6) for v in result["target_center"]],
+        )
+
+    def test_freecad_matches_index_selected_shell_face_by_signature_not_index(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(2.0, 3.0, 4.0)
+            selected_face = box.get_faces()[2]
+            expected_center = selected_face.get_center()
+            scad.shell_rsolid(box, [selected_face], 0.1)
+
+        payload = json.loads(scad.export_model_json(session))
+        shell_node = next(
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_shell_rsolid"
+        )
+        shell_node["params"]["selected_face_indices"] = [0]
+        payload_text = json.dumps(payload)
+        probe = f"""
+import json
+import FreeCAD as App
+
+doc = App.openDocument(FCSTD_PATH)
+shell = [obj for obj in doc.Objects if getattr(obj, 'SimpleCADOp', '') == 'make_shell_rsolid'][-1]
+source, names = shell.Faces
+target_center = ({float(expected_center.x)}, {float(expected_center.y)}, {float(expected_center.z)})
+matched = []
+for name in names:
+    idx = int(str(name)[4:]) - 1
+    face = source.Shape.Faces[idx]
+    center = face.CenterOfMass
+    matched.append([name, float(center.x), float(center.y), float(center.z)])
+with open(OUT_PATH, 'w', encoding='utf-8') as fh:
+    json.dump({{
+        'faces': matched,
+        'target_center': target_center,
+    }}, fh)
+"""
+        result = self._inspect_fcstd_json(payload_text, probe)
+        self.assertEqual(len(result["faces"]), 1)
+        self.assertEqual(
+            [round(v, 6) for v in result["faces"][0][1:]],
+            [round(v, 6) for v in result["target_center"]],
+        )
+
+    def test_freecad_ambiguous_signature_raises_instead_of_taking_first(self):
+        with GraphSession() as session:
+            box = scad.make_box_rsolid(2.0, 2.0, 2.0)
+            scad.fillet_rsolid(box, box.get_edges()[:1], 0.1)
+
+        payload = json.loads(scad.export_model_json(session))
+        fillet_node = next(
+            node
+            for node in payload["graph"]["nodes"]
+            if node["op"] == "make_fillet_rsolid"
+        )
+        item = fillet_node["params"]["selected_subshapes"]["items"][0]
+        signature = item["geometry_signature"]
+        signature.pop("center", None)
+        signature.pop("midpoint", None)
+        signature.pop("endpoints", None)
+        signature.pop("bbox", None)
+        signature["curve_type"] = "line"
+        signature["length"] = 2.0
+
+        freecad_cmd = self._discover_freecadcmd()
+        if not freecad_cmd:
+            self.skipTest("freecadcmd not available")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            script_path = os.path.join(tmp_dir, "ambiguous.py")
+            script = scad.translate_model_json_to_freecad_script(json.dumps(payload))
+            with open(script_path, "w", encoding="utf-8") as fh:
+                fh.write(script)
+            result = subprocess.run(
+                [freecad_cmd, script_path],
+                text=True,
+                capture_output=True,
+            )
+        self.assertIn(
+            "ambiguous geometry signature matched multiple candidates",
+            result.stderr + result.stdout,
+        )
 
     def test_translate_model_json_multi_tool_cut_affects_fcstd_result(self):
         with GraphSession() as session:

--- a/test/test_model_json.py
+++ b/test/test_model_json.py
@@ -364,14 +364,21 @@ class TestModelJson(unittest.TestCase):
         self.assertEqual(
             selection_schema["replay_resolution_order"],
             [
+                "geometry_signature",
                 "explicit_topo_refs",
-                "stable_indices",
-                "selection_query",
-                "selector_hint",
+                "legacy_index_fallback",
+                "legacy_selection_query",
+                "legacy_selector_hint",
             ],
         )
+        self.assertEqual(selection_schema["selection_param"], "selected_subshapes")
         self.assertEqual(selection_schema["edge_param"], "selected_edges")
         self.assertEqual(selection_schema["face_param"], "selected_faces")
+        selected_items = fillet_node["params"]["selected_subshapes"]["items"]
+        self.assertEqual(len(selected_items), 2)
+        self.assertEqual(selected_items[0]["kind"], "edge")
+        self.assertIn("geometry_signature", selected_items[0])
+        self.assertEqual(selected_items[0]["order"], 0)
         self.assertTrue(
             set(selection_schema["required_topo_ref_fields"]).issubset(
                 selected_edge_ref.keys()

--- a/test/test_rearchitecture_2_0_contract.py
+++ b/test/test_rearchitecture_2_0_contract.py
@@ -279,9 +279,11 @@ class TestRearchitecture20IoContracts(unittest.TestCase):
         self.assertEqual(
             selection_schema["replay_resolution_order"],
             [
+                "geometry_signature",
                 "explicit_topo_refs",
-                "stable_indices",
-                "selection_query",
-                "selector_hint",
+                "legacy_index_fallback",
+                "legacy_selection_query",
+                "legacy_selector_hint",
             ],
         )
+        self.assertEqual(selection_schema["selection_param"], "selected_subshapes")

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -390,6 +390,29 @@ class TestReplay(unittest.TestCase):
         self.assertIsInstance(results[0], scad.Solid)
         self.assertAlmostEqual(results[0].get_volume(), filleted.get_volume(), places=5)
 
+    def test_replay_ambiguous_selected_subshape_signature_raises(self):
+        with scad.GraphSession() as session:
+            box = scad.make_box_rsolid(2.0, 2.0, 2.0)
+            scad.fillet_rsolid(box, box.get_edges()[:1], 0.1)
+
+        payload = json.loads(export_graph_json(session.graph))
+        fillet_node = next(
+            node for node in payload["nodes"] if node["op"] == "make_fillet_rsolid"
+        )
+        signature = fillet_node["params"]["selected_subshapes"]["items"][0][
+            "geometry_signature"
+        ]
+        signature.pop("center", None)
+        signature.pop("midpoint", None)
+        signature.pop("endpoints", None)
+        signature.pop("bbox", None)
+        signature["curve_type"] = "line"
+        signature["length"] = 2.0
+
+        restored = import_graph_json(json.dumps(payload))
+        with self.assertRaisesRegex(ValueError, "ambiguous geometry signature"):
+            replay_graph(restored)
+
     def test_replay_shell_roundtrip_with_selector_hint_fallback(self):
         with scad.GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)


### PR DESCRIPTION
## 主要改动

- 扩展 `selected_subshapes` 序列化，覆盖更多 face/edge 消费路径。
- `make_wire_from_edges_rwire` 现在支持从已有 solid edge 构造 wire 时记录 edge geometry signature。
- `make_face_from_wire_rface` 现在支持从已有 face boundary wire 记录 boundary edge signatures。
- `extrude_rsolid` / `revolve_rsolid` 现在支持从已有 solid face 作为 profile 时按 signature 匹配。
- `loft_rsolid` 支持从已有 solid face boundary wires 作为 profiles。
- `sweep_rsolid` 支持 profile face 和 path edge 都来自已有 solid 的情况。
- `translate_shape` / `rotate_shape` / `mirror_shape` 支持输入为 selected face / edge / wire 时记录并匹配 geometry signature。
- FreeCAD translator 新增统一的 selected source feature 构造逻辑。
- replay 逻辑同步支持这些新的 selected subshape payload。
- 旧 graph 的 `selected_edge_indices` / `selected_face_indices` 仍保留为 legacy fallback，并带 warning。

## 背景

QL 和 index 选择只应该发生在 SimpleCAD runtime 中。导出后不能假设 SimpleCAD/OCP 的 index 与 FreeCAD 的 `EdgeN` / `FaceN` 一致。

新的 graph 保存的是“当时实际选中的子拓扑的几何签名”，FreeCAD 端不 replay QL，也不直接信任 SimpleCAD index，而是根据几何特征重新定位对应子拓扑。

## 验证

已通过：

- `uv run pytest test/test_freecad_translator.py -q`
- `uv run pytest test/test_model_json.py test/test_serialization.py test/test_rearchitecture_2_0_contract.py -q`
- `uv run pytest -q`
- `git diff --check`