### PR TITLE
Support indexed geo select nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,191 +1,142 @@
 # SimpleCADAPI
 
-SimpleCADAPI is an OCP-native imperative CAD modeling Python package. It keeps the 1.x-style functional API while adding v2 graph recording, expression parameters, and replayable model JSON workflows.
+SimpleCADAPI is an OCP-native Python SDK for building CAD models with clear,
+functional operations and replayable model graphs. It wraps OpenCascade geometry
+in a compact public API for creating solids, applying features, tagging semantic
+intent, querying topology, exporting manufacturing files, and translating recorded
+models into FreeCAD workflows.
 
-## README Scope
+Current beta: `simplecadapi==2.0.0b3`.
 
-This README only covers package-level capabilities, installation methods, publishing/packaging workflows, and Skills usage instructions.
-Experimental scripts and temporary modeling examples are not included as formal documentation.
+## What It Provides
 
-## Package Installation (Python Package Managers)
+- OCP-native shape types: `Vertex`, `Edge`, `Wire`, `Face`, and `Solid`.
+- Functional modeling operations for primitives, profiles, extrude, revolve,
+  loft, sweep, booleans, transforms, patterns, fillets, chamfers, and shells.
+- Replayable modeling with `GraphSession`, `export_model_json(...)`,
+  `import_model_json(...)`, and `replay_model_json(...)`.
+- Expression parameters with `var(...)`, arithmetic expressions, and serialized
+  expression graphs.
+- QL selectors for geometry grounding, topology queries, and stable feature
+  selections.
+- Semantic tags through `apply_tag(shape, tag)` and `list_tags(shape)`.
+- STEP/STL export and FreeCAD translation helpers for script or `.FCStd` output.
 
-Current package name: `simplecadapi` (see `pyproject.toml` for the version).
-
-### Method A: Install from package repository with pip
+## Install
 
 ```bash
 pip install simplecadapi
 ```
 
-Optional development dependencies:
-
-```bash
-pip install "simplecadapi[dev]"
-```
-
-### Method B: Install with uv
-
-Install in the current virtual environment:
-
-```bash
-uv pip install simplecadapi
-```
-
-Add as a project dependency in `pyproject.toml`:
+With `uv`:
 
 ```bash
 uv add simplecadapi
 ```
 
-### Method C: Install from local build artifacts
-
-Build a local wheel/sdist first if you want to install from local artifacts:
+For local development from this repository:
 
 ```bash
-uv build
+uv sync --group dev
 ```
 
-## Quick Verification of Installation
+## Quick Start
+
+```python
+from pathlib import Path
+
+import simplecadapi as scad
+
+out = Path("out")
+out.mkdir(exist_ok=True)
+
+base = scad.make_box_rsolid(60.0, 36.0, 8.0, bottom_face_center=(0.0, 0.0, 0.0))
+hole = scad.make_cylinder_rsolid(5.0, 14.0, bottom_face_center=(0.0, 0.0, -3.0))
+slot = scad.make_box_rsolid(18.0, 8.0, 14.0, bottom_face_center=(14.0, 0.0, -3.0))
+
+part = scad.cut_rsolidlist(base, hole, slot)
+boss = scad.make_cylinder_rsolid(8.0, 7.0, bottom_face_center=(-18.0, 0.0, 8.0))
+part = scad.union_rsolid(part, boss)
+part = scad.apply_tag(part, "role.demo.bracket")
+
+print("volume", round(part.get_volume(), 3))
+print("faces", len(part.get_faces()))
+print("tags", scad.list_tags(part))
+
+scad.export_step(part, str(out / "bracket.step"))
+scad.export_stl(part, str(out / "bracket.stl"))
+```
+
+## Replayable Modeling
+
+Use `GraphSession` when a model should be inspectable, serializable, replayable,
+or translated into another CAD environment.
 
 ```python
 import simplecadapi as scad
+from simplecadapi import ql as Q
 
-box = scad.make_box_rsolid(10.0, 20.0, 30.0)
-scad.export_stl(box, "example_box.stl")
-scad.export_step(box, "example_box.step")
+with scad.GraphSession() as session:
+    body = scad.make_box_rsolid(40.0, 24.0, 10.0, bottom_face_center=(0.0, 0.0, 0.0))
+    cutter = scad.make_cylinder_rsolid(4.0, 16.0, bottom_face_center=(0.0, 0.0, -3.0))
+    drilled = scad.cut_rsolidlist(body, cutter)
+
+    bottom_circle = (
+        Q.edges()
+        .where(Q.curve_type("circle"))
+        .order_by(Q.center_axis("z"))
+        .take(1)
+        .exactly(1)
+    )
+    final = scad.chamfer_rsolid(drilled, bottom_circle, 0.6)
+
+model_json = scad.export_model_json(session)
+rebuilt = scad.replay_model_json(model_json)
+
+print("recorded_nodes", session.graph.node_count)
+print("replayed_outputs", len(rebuilt))
 ```
 
-## How to Package SDK Skills
+## Modeling Mental Model
 
-This project provides the `skill-pack` CLI for generating lightweight SDK reference skills: **No built-in SDK source code**, focused on API and architecture descriptions.
+- Start from design intent: reference axes, critical profiles, and the features
+  that produce the final solid.
+- Build from lower-dimensional geometry to higher-dimensional geometry: profile
+  wires/faces first, then solid features such as extrude, revolve, loft, and
+  sweep.
+- Keep operations functional. Create new values with public functions such as
+  `make_rectangle_rface(...)`, `extrude_rsolid(...)`, `cut_rsolidlist(...)`, and
+  `fillet_rsolid(...)`.
+- Use tags for semantic intent and selection anchors, for example
+  `role.mounting.surface`, `anchor.datum.primary`, or `group.fasteners`.
+- Store numeric and geometric facts in metadata or graph payloads, not in tags.
+- Use QL to ground selections by geometry facts rather than relying on topology
+  iteration order.
+- When an indexed topology pick is intentional, pass the index to the plural
+  child-geometry getter, such as `get_edges(index)`, `get_faces(index)`,
+  `get_wires(index)`, or `get_vertices(index)`, so replayable graph workflows
+  preserve the pick as a geo select node.
+- Use model JSON as the interchange boundary for replay, tests, and FreeCAD
+  translation.
 
-### 1) Packaging Command
+## FreeCAD Translation
 
-Execute in the repository root directory:
-
-```bash
-uv run skill-pack --refresh-docs --archive --skill-name simplecadapi
-```
-
-Common parameters:
-
-- `--output-root <dir>`: Output directory (default `./skills`)
-- `--package-name <pkg>`: Runtime installation package name (default reads from `project.name`)
-- `--package-version <ver>`: Runtime installation version (default reads from `project.version`)
-- `--no-clean`: Do not clean existing output directory
-- `--archive`: Additionally generate `<skill-name>.tar.gz`
-
-### 2) Packaging Result Structure
-
-After packaging, you will get a directory similar to:
-
-- `skills/simplecadapi/SKILL.md`
-- `skills/simplecadapi/references/`
-- `skills/simplecadapi/references/docs/api/`
-- `skills/simplecadapi/references/docs/core/`
-
-### 3) Read the SDK skill
-
-```bash
-cd skills/simplecadapi
-```
-
-Key entry points:
-
-- `skills/simplecadapi/SKILL.md`
-- `skills/simplecadapi/references/SDK_OVERVIEW.md`
-- `skills/simplecadapi/references/SDK_SURFACES.md`
-- `skills/simplecadapi/references/V2_MODELING_WORKFLOWS.md`
-- `skills/simplecadapi/references/SDK_PACKAGE_SUMMARY.md`
-- `skills/simplecadapi/references/docs/api/README.md`
-- `skills/simplecadapi/references/docs/core/README.md`
-
-### 4) Preferred v2 replay workflow
+Recorded model JSON can be translated into a FreeCAD Python script:
 
 ```python
-from simplecadapi import GraphSession, export_model_json, replay_model_json
-
-with GraphSession() as session:
-    ...
-
-model_json = export_model_json(session)
-rebuilt = replay_model_json(model_json)
-print(len(rebuilt))
+script = scad.translate_model_json_to_freecad_script(model_json)
 ```
 
-## Serialization and Replay Docs
+If FreeCAD or FreeCADCmd is available, the same model JSON can be written as an
+`.FCStd` file:
 
-For detailed operation-by-operation JSON formats and replay behavior, see:
-
-- [`docs/core/serialization/README.md`](docs/core/serialization/README.md)
-- [`docs/core/operation_graph_json_spec.md`](docs/core/operation_graph_json_spec.md)
-- [`examples/07_serialization_operation_tree.py`](examples/07_serialization_operation_tree.py)
-
-## Auto Tools
-
-The project includes 4 main CLIs:
-
-- `auto-docs-gen`: Generate `docs/api/` documentation from the public API source surface
-- `make-export`: Update imports/exports in `src/simplecadapi/__init__.py`
-- `evolve`: Extract functions from scripts for repository-managed evolve modules
-- `skill-pack`: Package thin SDK skill (documentation only)
-
-Examples:
-
-```bash
-uv run make-export --dry-run
-uv run auto-docs-gen
-uv run evolve path/to/your_case.py
-uv run skill-pack --refresh-docs --archive
+```python
+scad.translate_model_json_to_fcstd(model_json, "bracket.FCStd")
 ```
 
-## RAGFlow Documentation Sync
+## Examples
 
-`scripts/sync_ragflow_docs.py` is used to incrementally sync Markdown files under `docs/` to the specified RAGFlow dataset, chunked by H2 headings; the document's `chunk_method` is set to `manual`.
-
-Prepare the environment:
-
-```bash
-.venv/bin/python -m pip install ragflow-sdk
-```
-
-It is recommended to use `.env` (already added to `.gitignore`):
-
-```bash
-RAGFLOW_API_KEY=your_key_here
-RAGFLOW_BASE_URL=http://localhost
-RAGFLOW_DATASET_NAME=SimpleCADAPI
-```
-
-Run the sync:
-
-```bash
-set -a && source .env && set +a
-.venv/bin/python scripts/sync_ragflow_docs.py --create-dataset
-```
-
-Common parameters:
-
-- `--dataset-id` / `RAGFLOW_DATASET_ID`: Directly specify the dataset ID (avoid name conflicts)
-- `--delete-removed`: Delete documents that have been removed locally
-- `--dry-run`: Only preview changes without executing writes
-- `--progress-interval N`: Print progress every N documents
-
-## Development and Testing
-
-Local development installation (editable):
-
-```bash
-uv pip install -e ".[dev]"
-```
-
-Run unit tests:
-
-```bash
-uv run python -m unittest test/test_all_features.py
-```
-
-Run examples:
+Run examples from the source checkout:
 
 ```bash
 uv run python examples/01_basic_modeling.py
@@ -196,18 +147,23 @@ uv run python examples/06_parametric_gear_model.py
 uv run python examples/07_serialization_operation_tree.py
 ```
 
-## Core Design Constraints (Brief)
+## Documentation
 
-- API functions uniformly use `snake_case` and reflect return types in function names (e.g., `*_rsolid`, `*_rwire`).
-- Core types are OCP-native wrappers and are kept as stable as possible; functionality is extended by adding new functions (Open-Closed Principle).
-- Support `SimpleWorkplane` context for local coordinate modeling.
-- Export interfaces support single entities, multiple entities, and nested list inputs.
+- Public API reference: [`docs/api/`](docs/api/)
+- Core type and modeling notes: [`docs/core/`](docs/core/)
+- Serialization and replay details:
+  [`docs/core/serialization/README.md`](docs/core/serialization/README.md)
+- Operation graph JSON spec:
+  [`docs/core/operation_graph_json_spec.md`](docs/core/operation_graph_json_spec.md)
 
-## Documentation Entry Points
+## Development
 
-- API documentation: `docs/api/`
-- Core documentation: `docs/core/`
+```bash
+uv sync --group dev
+uv run python -m pytest test tests
+python3 -m compileall src/simplecadapi
+```
 
 ## License
 
-MIT, see `LICENSE`.
+MIT, see [`LICENSE`](LICENSE).

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,6 +1,6 @@
 # SimpleCAD API Index
 
-This index includes generated docs for the public SimpleCAD API surface, including v2 graph, expression, and model JSON workflows.
+This index includes generated docs for the public SimpleCAD API surface, including geometry operations, graph/model JSON workflows, expressions, QL, and export helpers.
 
 ## Import Surfaces
 
@@ -64,6 +64,11 @@ This index includes generated docs for the public SimpleCAD API surface, includi
 
 - [export_step](export_step.md) *(from operations.py)* `top-level`
 - [export_stl](export_stl.md) *(from operations.py)* `top-level`
+
+## FreeCAD Translation
+
+- [translate_model_json_to_fcstd](translate_model_json_to_fcstd.md) *(from freecad_translator.py)* `top-level`
+- [translate_model_json_to_freecad_script](translate_model_json_to_freecad_script.md) *(from freecad_translator.py)* `top-level`
 
 ## Modeling Graph and Replay
 

--- a/docs/api/translate_model_json_to_fcstd.md
+++ b/docs/api/translate_model_json_to_fcstd.md
@@ -1,0 +1,17 @@
+# translate_model_json_to_fcstd
+
+## API Definition
+
+```python
+def translate_model_json_to_fcstd(json_str: str, output_path: str, *, document_name: str = 'SimpleCADModel', freecad_cmd: Optional[str] = None) -> str
+```
+
+*Source: freecad_translator.py*
+
+## Import Surface
+
+- top-level: `from simplecadapi import translate_model_json_to_fcstd`
+
+## Description
+
+Translate canonical model JSON to `.FCStd` via FreeCADCmd/FreeCAD.

--- a/docs/api/translate_model_json_to_freecad_script.md
+++ b/docs/api/translate_model_json_to_freecad_script.md
@@ -1,0 +1,17 @@
+# translate_model_json_to_freecad_script
+
+## API Definition
+
+```python
+def translate_model_json_to_freecad_script(json_str: str, document_name: str = 'SimpleCADModel') -> str
+```
+
+*Source: freecad_translator.py*
+
+## Import Surface
+
+- top-level: `from simplecadapi import translate_model_json_to_freecad_script`
+
+## Description
+
+Translate exported model JSON into a FreeCAD Python script.

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -2,7 +2,7 @@
 
 This directory documents the core public object model for SimpleCADAPI.
 
-SimpleCADAPI 2.x is OCP-native at runtime: public geometry objects are thin Python wrappers around OpenCascade/OCP shapes exposed through the `.wrapped` attribute. The package keeps the 1.x-style functional modeling API while adding graph recording, expression parameters, and replayable model JSON.
+SimpleCADAPI is OCP-native at runtime: public geometry objects are thin Python wrappers around OpenCascade/OCP shapes exposed through the `.wrapped` attribute. The package provides functional modeling operations, expression parameters, QL selectors, and replayable model JSON.
 
 ## Core Classes Overview
 
@@ -57,8 +57,9 @@ SimpleWorkplane  ← local modeling context
 - **Shape-first API**: users work with `Vertex`, `Edge`, `Wire`, `Face`, and `Solid`, not graph nodes.
 - **Functional modeling style**: public operations return new geometry values, e.g. `make_box_rsolid(...)`, `cut_rsolidlist(...)`, `fillet_rsolid(...)`.
 - **OCP-native runtime**: geometry construction, topology traversal, properties, booleans, transforms, and export use OCP/OpenCascade helpers.
-- **Replayable v2 workflows**: `GraphSession` can record a canonical low-level operation graph and `export_model_json()` can serialize it for `replay_model_json()`.
+- **Replayable graph workflows**: `GraphSession` can record a canonical low-level operation graph and `export_model_json()` can serialize it for `replay_model_json()`.
 - **Tags and metadata**: tags are useful for lightweight semantics; structured numeric facts should be stored in metadata such as `metadata["geo"]`.
+- **Indexed topology access**: use plural methods such as `get_edges()` and `get_faces()` for enumeration, and pass an index to the same getter, such as `get_edges(index)` or `get_faces(index)`, for intentional indexed picks that should become graph selection nodes.
 
 ## Basic Usage
 
@@ -98,6 +99,3 @@ print(len(rebuilt))
 - [User Guide](../../README.md)
 - [JSON Operation Graph Spec](operation_graph_json_spec.md)
 - [Serialization and Replay Operation Guides](serialization/)
-- [Declarative Constraint Layout Design Draft](declarative_constraints.md)
-- [SimpleCADAPI 2.0 Re-architecture Design](rearchitecture_2_0.md)
-- [SimpleCADAPI 2.0 Requirements and Acceptance](rearchitecture_2_0_requirements.md)

--- a/docs/core/operation_graph_json_spec.md
+++ b/docs/core/operation_graph_json_spec.md
@@ -116,7 +116,7 @@ source API 名字不等于 canonical graph op 名字。Composite source API 可�
 ```json
 {
   "schema_version": "2.0",
-  "producer_version": "2.0.0b2",
+  "producer_version": "2.0.0b3",
   "capabilities": {
     "selection_ref_strategies": true,
     "geo_select_nodes": true,
@@ -151,7 +151,7 @@ source API 名字不等于 canonical graph op 名字。Composite source API 可�
 | Field | Type | Meaning |
 | --- | --- | --- |
 | `selection_ref_strategies` | `bool` | detail feature 支持显式 topo refs / index / query 等多种选择策略 |
-| `geo_select_nodes` | `bool` | QL-derived detail selections can be serialized as `make_select_*` geo selector nodes |
+| `geo_select_nodes` | `bool` | detail selections from QL or indexed child-geometry getters can be serialized as `make_select_*` geo selector nodes |
 | `selector_hint_fallback` | `bool` | replay 时支持 selector hint 近似匹配回退 |
 | `display_payload` | `bool` | node 中包含 `display` 字段 |
 | `topology_delta_summary` | `bool` | 当前为 `false`，表示没有额外 summary-only delta schema |
@@ -267,7 +267,7 @@ source API 名字不等于 canonical graph op 名字。Composite source API 可�
 规则：
 
 - 如果某个参数没有表达式来源，则 `param_exprs` 中没有该键
-- 离散索引参数不会被表达式提升，例如：
+- 计数和 legacy fallback 索引参数不会被表达式提升，例如：
   - `selected_edge_indices`
   - `selected_face_indices`
   - `count`
@@ -425,7 +425,7 @@ detail feature 使用显式选择引用来稳定 replay。
     "geo_select_nodes",
     "selection_query",
     "explicit_topo_refs",
-    "stable_indices",
+    "legacy_indices",
     "selector_hint"
   ]
 }
@@ -468,7 +468,7 @@ detail feature 使用显式选择引用来稳定 replay。
 
 ### 8.4 Geo Select Nodes
 
-当 detail feature 使用 QL selector 时，新 graph 不把 QL 文本作为主要事实来源。运行时先解析 QL，读取每个被选中子形状的几何事实，并为每一项生成一个 canonical select 节点：
+当 detail feature 使用 QL selector 或 `get_edges(index)` / `get_faces(index)` 这类 indexed child-geometry getter 时，新 graph 不把 QL 文本或 Python list position 作为主要事实来源。运行时读取每个被选中子形状的几何事实，并为每一项生成一个 canonical select 节点：
 
 - `make_select_redge`
 - `make_select_rface`
@@ -476,7 +476,7 @@ detail feature 使用显式选择引用来稳定 replay。
 - `make_select_rvertex`
 - `make_select_rsolid`
 
-如果 QL 结果是 list，则每个元素对应一个独立 select 节点。feature node 通过 `selected_edge_node_ids` 或 `selected_face_node_ids` 指向这些节点。
+如果选择结果是 list，则每个元素对应一个独立 select 节点。feature node 通过 `selected_edge_node_ids` 或 `selected_face_node_ids` 指向这些节点。
 
 select node 示例：
 
@@ -488,7 +488,6 @@ select node 示例：
     "geo_selector": {
       "mode": "geo_exact",
       "kind": "edge",
-      "source_index": 1,
       "geom_type": "CIRCLE",
       "length": 6.283185307179586,
       "center": [0.0, 0.0, 0.0],
@@ -506,7 +505,7 @@ select node 示例：
 }
 ```
 
-`geo_selector` 不包含 tags，也不通过 tag 搜索。它固定到运行时选中对象的完整可见几何事实；`source_index` 用来保证在同一运行位置的 FreeCAD/OCP 子形状序列中直接命中绝对对应项，完整几何数据用于 fallback、审计和外部 adapter 校验。
+`geo_selector` 不包含 tags，也不通过 tag 搜索。它固定到运行时选中对象的完整可见几何事实；完整几何数据用于 replay、审计和外部 adapter 校验。
 
 ### 8.5 selection_query fallback
 
@@ -592,7 +591,7 @@ detail feature replay 的固定解析顺序为：
 1. `selected_edge_node_ids` / `selected_face_node_ids` 指向的 geo select nodes
 2. `selection_query` fallback
 3. `selected_edges` / `selected_faces` 中的显式 topo refs
-4. `selected_edge_indices` / `selected_face_indices`
+4. `selected_edge_indices` / `selected_face_indices` legacy fallback
 5. `selector_hint`
 
 适配器若要实现等价行为，必须保持这个顺序。
@@ -1272,8 +1271,8 @@ Notes:
 | `radius` | scalar | fillet radius |
 | `edge_count` | `int` | number of targeted edges |
 | `selected_edges` | `array<TopoRefWithHint>` | explicit edge refs |
-| `selected_edge_node_ids` | `array<string>` | primary geo select node refs for QL-derived selections |
-| `selected_edge_indices` | `array<int>` | stable index fallback against `solid.get_edges()` |
+| `selected_edge_node_ids` | `array<string>` | primary geo select node refs for QL/index-derived selections |
+| `selected_edge_indices` | `array<int>` | legacy index fallback when select nodes are unavailable |
 | `selection_query` | `ShapeSelector object` | legacy/fallback serialized QL selector |
 
 #### `make_chamfer_rsolid`
@@ -1287,8 +1286,8 @@ Notes:
 | `distance` | scalar | chamfer distance |
 | `edge_count` | `int` | number of targeted edges |
 | `selected_edges` | `array<TopoRefWithHint>` | explicit edge refs |
-| `selected_edge_node_ids` | `array<string>` | primary geo select node refs for QL-derived selections |
-| `selected_edge_indices` | `array<int>` | stable index fallback |
+| `selected_edge_node_ids` | `array<string>` | primary geo select node refs for QL/index-derived selections |
+| `selected_edge_indices` | `array<int>` | legacy index fallback when select nodes are unavailable |
 | `selection_query` | `ShapeSelector object` | legacy/fallback serialized QL selector |
 
 #### `make_shell_rsolid`
@@ -1302,8 +1301,8 @@ Notes:
 | `thickness` | scalar | shell thickness |
 | `removed_face_count` | `int` | number of faces removed |
 | `selected_faces` | `array<TopoRefWithHint>` | explicit face refs |
-| `selected_face_node_ids` | `array<string>` | primary geo select node refs for QL-derived selections |
-| `selected_face_indices` | `array<int>` | stable index fallback against `solid.get_faces()` |
+| `selected_face_node_ids` | `array<string>` | primary geo select node refs for QL/index-derived selections |
+| `selected_face_indices` | `array<int>` | legacy index fallback when select nodes are unavailable |
 | `selection_query` | `ShapeSelector object` | legacy/fallback serialized QL selector |
 
 ### 14.7 Pattern Ops
@@ -1409,7 +1408,7 @@ SDF / scalar field modeling is temporarily removed from the supported public sur
 1. 优先消费 `model.json`
 2. 若要做工业 interchange，请直接消费 canonical low-level `graph`
 3. 若要恢复参数化，请同时读取 `params`、`param_exprs`、`expression_graph`
-4. detail feature 必须按声明顺序解析选择：geo select nodes -> query fallback -> explicit refs -> indices -> hint
+4. detail feature 必须按声明顺序解析选择：geo select nodes -> query fallback -> explicit refs -> legacy indices -> hint
 5. 不要依赖 `display.summary` 解析业务语义
 
 ### 17.2 Tolerances For Consumers
@@ -1420,7 +1419,7 @@ SDF / scalar field modeling is temporarily removed from the supported public sur
 - `output_slot` 在深层 param 对象中可能是 `0.0`
 - `tags` 可能为空
 - `semantic_delta` / `topo_delta` 可能缺失
-- `selection_query` 是旧 payload / 手写 payload fallback；新 QL detail selections 应优先产生 geo select nodes
+- `selection_query` 是旧 payload / 手写 payload fallback；新 detail selections 应优先产生 geo select nodes
 
 ### 17.3 Recommended Minimal Interchange Subset
 
@@ -1435,7 +1434,7 @@ SDF / scalar field modeling is temporarily removed from the supported public sur
 
 - `selected_edge_node_ids` / `selected_face_node_ids` and their `make_select_*` nodes
 - `selected_edges` / `selected_faces`
-- `selected_edge_indices` / `selected_face_indices`
+- `selected_edge_indices` / `selected_face_indices` as legacy fallback
 - `selection_query` fallback, when present
 - `selector_hint`
 
@@ -1474,9 +1473,9 @@ SDF / scalar field modeling is temporarily removed from the supported public sur
         }
       }
     ],
-    "selected_edge_indices": [0, 1]
+    "selected_edge_node_ids": ["node_select_edge_0", "node_select_edge_1"]
   },
-  "inputs": ["node_f7e1ea08"],
+  "inputs": ["node_f7e1ea08", "node_select_edge_0", "node_select_edge_1"],
   "output_count": 1
 }
 ```

--- a/docs/core/serialization/README.md
+++ b/docs/core/serialization/README.md
@@ -1,6 +1,6 @@
 # Serialization and Replay Operation Guides
 
-This directory documents how SimpleCADAPI 2.x serializes replayable modeling operations into the canonical low-level `model.json` operation graph.
+This directory documents how SimpleCADAPI serializes replayable modeling operations into the canonical low-level `model.json` operation graph.
 
 The long-form schema reference remains [`../operation_graph_json_spec.md`](../operation_graph_json_spec.md). These files are more practical, operation-by-operation guides intended for people comparing source code with exported JSON.
 
@@ -51,7 +51,6 @@ Many user-facing functions are convenience APIs. During an active `GraphSession`
 
 - [Primitive and profile operations](primitives-and-profiles.md)
 - [Features, booleans, transforms, patterns, and selectors](features-booleans-transforms.md)
-- [Scalar field surfaces](scalar-fields.md)
 - [Expressions and replay behavior](expressions-and-replay.md)
 
 ## Example

--- a/docs/core/serialization/expressions-and-replay.md
+++ b/docs/core/serialization/expressions-and-replay.md
@@ -1,6 +1,6 @@
 # Expressions and Replay Behavior
 
-SimpleCADAPI 2.x stores expression-backed parameters in two places:
+SimpleCADAPI stores expression-backed parameters in two places:
 
 1. `node.params`: numeric / JSON-compatible snapshot used by simple replay
 2. `node.param_exprs`: references into the top-level `expression_graph`
@@ -127,7 +127,6 @@ If an example creates many independent showcase shapes, `leaf_ids` may contain m
 ## Unsupported / lossy expression cases
 
 - Python callables are not serialized as expressions.
-- Scalar-field Python callables are recorded as `opaque_callable` and cannot be replayed.
 - Some discrete selector data, topology refs, and counts are intentionally treated as JSON data rather than scalar expressions.
 
 ## Practical inspection snippet

--- a/docs/core/serialization/features-booleans-transforms.md
+++ b/docs/core/serialization/features-booleans-transforms.md
@@ -342,7 +342,6 @@ Serialized node:
         "selector_hint": {...}
       }
     ],
-    "selected_edge_indices": [0, 1, 2, 3],
     "selected_edge_node_ids": ["node_select_edge_0", "node_select_edge_1", "node_select_edge_2", "node_select_edge_3"]
   },
   "inputs": ["node_for_solid", "node_select_edge_0", "node_select_edge_1", "node_select_edge_2", "node_select_edge_3"],
@@ -350,14 +349,14 @@ Serialized node:
 }
 ```
 
-Each QL-selected edge is serialized as its own `make_select_redge` node whose `geo_selector` is fixed to the runtime-selected edge geometry. `geo_selector` does not contain tags; it uses geometry facts such as `source_index`, `geom_type`, `length`, `center`, endpoints, bbox, and `metadata_geo`.
+Each QL-selected or indexed getter-selected edge is serialized as its own `make_select_redge` node whose `geo_selector` is fixed to the runtime-selected edge geometry. `geo_selector` does not contain tags or source indices; it uses geometry facts such as `geom_type`, `length`, `center`, endpoints, bbox, and `metadata_geo`.
 
 Replay edge resolution order:
 
 1. Geo select nodes from `selected_edge_node_ids`
 2. Legacy/fallback `selection_query`, when present
 3. Explicit topo refs in `selected_edges`
-4. Stable indices in `selected_edge_indices`
+4. Legacy indices in `selected_edge_indices`, when select nodes are unavailable
 5. `selector_hint` fallback
 
 Then replay calls `fillet_rsolid(solid, resolved_edges, radius)`.
@@ -380,7 +379,6 @@ Serialized node shape is the same as fillet, except:
     "distance": 0.15,
     "edge_count": 4,
     "selected_edges": [...],
-    "selected_edge_indices": [...],
     "selected_edge_node_ids": [...]
   },
   "inputs": ["node_for_solid", "node_select_edge_0", "..."]
@@ -407,7 +405,6 @@ Serialized node:
     "thickness": 0.25,
     "removed_face_count": 1,
     "selected_faces": [...],
-    "selected_face_indices": [5],
     "selected_face_node_ids": ["node_select_face_0"]
   },
   "inputs": ["node_for_solid", "node_select_face_0"],
@@ -422,7 +419,7 @@ Replay face resolution order:
 1. Geo select nodes from `selected_face_node_ids`
 2. Legacy/fallback `selection_query`, when present
 3. Explicit topo refs in `selected_faces`
-4. Stable indices in `selected_face_indices`
+4. Legacy indices in `selected_face_indices`, when select nodes are unavailable
 5. `selector_hint` fallback
 
 Then replay calls `shell_rsolid(solid, resolved_faces, thickness)`.

--- a/docs/core/solid.md
+++ b/docs/core/solid.md
@@ -114,6 +114,23 @@ for i, face in enumerate(faces):
     print(f"面 {i}: 面积 {area:.3f}")
 ```
 
+### `get_faces(index)`
+
+Get one face by explicit index. In an active `GraphSession`, this intentional
+indexed pick is preserved as a graph geo select node.
+
+**Returns:**
+- `Face`: The selected face object
+
+**Example:**
+```python
+from simplecadapi import make_box_rsolid
+
+box = make_box_rsolid(width=4, height=3, depth=2)
+first_face = box.get_faces(0)
+print(first_face.get_area())
+```
+
 ### `get_edges()`
 
 Get all edges that make up the solid.
@@ -135,6 +152,23 @@ print(f"立方体有 {len(edges)} 条边")
 for i, edge in enumerate(edges):
     length = edge.get_length()
     print(f"边 {i}: 长度 {length:.3f}")
+```
+
+### `get_edges(index)`
+
+Get one edge by explicit index. In an active `GraphSession`, this intentional
+indexed pick is preserved as a graph geo select node.
+
+**Returns:**
+- `Edge`: The selected edge object
+
+**Example:**
+```python
+from simplecadapi import make_box_rsolid
+
+box = make_box_rsolid(width=4, height=3, depth=2)
+first_edge = box.get_edges(0)
+print(first_edge.get_length())
 ```
 
 ### `auto_tag_faces(geometry_type)`

--- a/docs/core/wire.md
+++ b/docs/core/wire.md
@@ -371,7 +371,7 @@ def create_wire_sequence():
         segments.append(segment)
     
     # 分析序列
-    total_path_length = sum(seg.get_edges()[0].get_length() for seg in segments)
+    total_path_length = sum(seg.get_edges(0).get_length() for seg in segments)
     
     print(f"路径段数: {len(segments)}")
     print(f"总路径长度: {total_path_length:.3f}")

--- a/examples/01_basic_modeling.py
+++ b/examples/01_basic_modeling.py
@@ -1,4 +1,4 @@
-"""Basic shape-first modeling with the 1.x-style functional API.
+"""Basic shape-first modeling with the functional API.
 
 Run from the repository root with:
     uv run python examples/01_basic_modeling.py

--- a/examples/03_expressions.py
+++ b/examples/03_expressions.py
@@ -1,4 +1,4 @@
-"""Expression parameters inside the v2 graph/model workflow.
+"""Expression parameters inside a replayable graph/model workflow.
 
 Run from the repository root with:
     uv run python examples/03_expressions.py

--- a/examples/07_serialization_operation_tree.py
+++ b/examples/07_serialization_operation_tree.py
@@ -1,4 +1,4 @@
-"""Show how source code maps to the serializable v2 operation tree.
+"""Show how source code maps to the serializable operation tree.
 
 Run from the repository root with:
     uv run python examples/07_serialization_operation_tree.py
@@ -66,7 +66,7 @@ with scad.GraphSession() as session:
     )
     drilled_plate = scad.cut_rsolidlist(plate, hole)
 
-    # Core wire/profile API: point, line, circle, arc, spline, helix, wire assembly,
+    # Core wire/profile API: point, line, circle, arc, spline, helix, wire construction,
     # face construction.  These are kept small and placed away from the plate so
     # they are easy to inspect in the graph without making the shape complicated.
     source_step("03 make_point_rvertex")
@@ -113,9 +113,8 @@ with scad.GraphSession() as session:
         [(9.0, -5.0, plate_t), (10.0, -4.0, plate_t), (11.0, -5.0, plate_t)]
     )
 
-    # Basic solid constructors that lower to replayable core operations, plus the
-    # scalar-field surface op from the canonical replayable op set.
-    source_step("06 make_sphere_rsolid, make_cone_rsolid, make_field_surface_rsolid")
+    # Basic solid constructors that lower to replayable core operations.
+    source_step("06 make_sphere_rsolid, make_cone_rsolid")
     sphere = scad.make_sphere_rsolid(1.0, center=(-7.0, 6.0, plate_t + 1.0))
     cone = scad.make_cone_rsolid(
         1.2,
@@ -123,13 +122,6 @@ with scad.GraphSession() as session:
         top_radius=0.4,
         bottom_face_center=(-3.0, 6.0, plate_t),
     )
-    field_shape = scad.make_field_surface_rsolid(
-        scad.field.make_sphere_rscalarfield((0.0, 0.0, 0.0), 0.75),
-        bounds=((-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)),
-        resolution=(8, 8, 8),
-    )
-    field_shape = scad.translate_shape(field_shape, (-11.0, 6.0, plate_t + 1.0))
-
     # Feature operations.
     source_step("07 revolve_rsolid, loft_rsolid, sweep_rsolid")
     revolve_profile = scad.make_polyline_rwire(
@@ -274,8 +266,6 @@ summary += dedent(
       `make_face_from_wire_rface` + `make_extrude_rsolid`.
     - `make_cylinder_rsolid(...)` lowers to a circle face plus `make_extrude_rsolid`.
     - `make_sphere_rsolid(...)` and `make_cone_rsolid(...)` lower to revolve chains.
-- `make_field_surface_rsolid(...)` records a serialized scalar-field tree in a
-  `make_field_surface_rsolid` node.
     - `make_rectangle_rwire`, `make_circle_rwire`, `make_polyline_rwire`, and
       single-arc/spline/helix wire helpers lower to edge + wire operations.
     - `linear_pattern_rsolidlist(...)` lowers to explicit `make_translate_rshape`

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,9 +5,9 @@ Generated STEP/STL/JSON files are written to `examples/out/`, which is ignored b
 
 ## Examples
 
-- `01_basic_modeling.py` — 1.x-style functional shape modeling, booleans, STEP/STL export.
+- `01_basic_modeling.py` — functional shape modeling, booleans, and STEP/STL export.
 - `02_graph_replay.py` — `GraphSession`, canonical model JSON export, and replay.
-- `03_expressions.py` — expression parameters captured in the v2 model graph.
+- `03_expressions.py` — expression parameters captured in a replayable model graph.
 - `05_loft_sweep_revolve.py` — profile operations: revolve, loft, and sweep.
 - `06_parametric_gear_model.py` — lightweight involute spur gear model JSON example for replay/export tests.
-- `07_serialization_operation_tree.py` — compact v2 serialization demo showing how source calls map to canonical operation-tree nodes, including expressions, primitive lowering, features, booleans, transforms, patterns, and detail operations.
+- `07_serialization_operation_tree.py` — compact serialization demo showing how source calls map to canonical operation-tree nodes, including expressions, primitive lowering, features, booleans, transforms, patterns, and detail operations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simplecadapi"
-version = "2.0.0b2"
+version = "2.0.0b3"
 description = "A simplified OCP-native CAD modeling Python API"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/skills/simplecadapi/SKILL.md
+++ b/skills/simplecadapi/SKILL.md
@@ -5,9 +5,9 @@ license: MIT
 compatibility: Documentation/reference bundle for current SimpleCADAPI surfaces.
 metadata:
   project: simplecadapi
-  version: 2.0.0b2
+  version: 2.0.0b3
   package-name: simplecadapi
-  package-version: 2.0.0b2
+  package-version: 2.0.0b3
 ---
 
 # SimpleCAD SDK Skill
@@ -59,6 +59,7 @@ metadata:
 - Use `GraphSession` when the model should be replayable, inspectable, exported as model JSON, or translated to another CAD system.
 - Treat model JSON as the interchange boundary. Prefer `export_model_json(session)` and `replay_model_json(payload)` over hand-authored operation payloads.
 - Use QL for precise grounding. Query faces, edges, centers, normals, areas, lengths, curve types, and tags; print only the facts needed to validate the current step.
+- Use `get_edges(index)`, `get_faces(index)`, `get_wires(index)`, or `get_vertices(index)` when an indexed topology pick is intentional; these picks are preserved as geo select nodes in replayable graph workflows.
 - Use tags for semantic intent and selection anchors, such as `role.mounting_surface`, `anchor.datum.primary`, `face.top`, or `group.fasteners`.
 - Keep numeric and geometric facts in metadata or graph payloads, not in tags.
 - When a QL-selected face or edge is used by a later feature, expect the graph/model workflow to preserve that selection as a stable geo select node.

--- a/skills/simplecadapi/references/MODELING_WORKFLOWS.md
+++ b/skills/simplecadapi/references/MODELING_WORKFLOWS.md
@@ -7,6 +7,7 @@
 - Use booleans and detail features after the base form is clear: cut openings, union intended merged bodies, then apply fillets, chamfers, or shell operations.
 - Use `GraphSession` whenever the result should be replayable, inspectable, serialized, or translated.
 - Use QL for grounding and selection. Query the facts you need, such as face normals, centers, areas, edge lengths, curve types, and tags.
+- Use indexed child-geometry getters such as `get_edges(index)` and `get_faces(index)` when an indexed topology pick is intentional.
 - Use semantic tags for design intent and anchors. Keep numeric measurements and geometry facts in metadata or model JSON payloads.
 - Treat `export_model_json()` as the interchange boundary for replay and CAD translation.
 - Validate incrementally: after each major step, print small QL-derived facts such as selected face count, top face center, edge count, volume, or replay result count.
@@ -61,7 +62,8 @@ print("rebuilt", len(rebuilt))
 
 ## 5) Selection and tag discipline
 
-- Prefer QL selectors over manual list indexing when selecting feature inputs.
+- Prefer QL selectors for semantic/geometric feature input selection.
+- Use `get_edges(index)`, `get_faces(index)`, `get_wires(index)`, or `get_vertices(index)` for intentional indexed picks in examples.
 - Attach semantic tags with `apply_tag(shape, tag)` and inspect with `list_tags(shape)`.
 - Use tags for intent, roles, anchors, groups, and topology names.
 - Store dimensions, positions, measured geometry, and descriptive payloads in metadata or model JSON, not in tags.

--- a/skills/simplecadapi/references/SDK_OVERVIEW.md
+++ b/skills/simplecadapi/references/SDK_OVERVIEW.md
@@ -1,8 +1,8 @@
 # SDK Overview
 
 - Project: `simplecadapi`
-- Version: `2.0.0b2`
-- Package distribution: `simplecadapi==2.0.0b2`
+- Version: `2.0.0b3`
+- Package distribution: `simplecadapi==2.0.0b3`
 
 ## What this skill bundles
 

--- a/skills/simplecadapi/references/SDK_PACKAGE_SUMMARY.md
+++ b/skills/simplecadapi/references/SDK_PACKAGE_SUMMARY.md
@@ -1,7 +1,7 @@
 # SDK Package Summary
 
 - Project: `simplecadapi`
-- Version: `2.0.0b2`
+- Version: `2.0.0b3`
 - Summary: A simplified OCP-native CAD modeling Python API
 
 ## Scope

--- a/skills/simplecadapi/references/docs/api/README.md
+++ b/skills/simplecadapi/references/docs/api/README.md
@@ -1,6 +1,6 @@
 # SimpleCAD API Index
 
-This index includes generated docs for the public SimpleCAD API surface, including v2 graph, expression, and model JSON workflows.
+This index includes generated docs for the public SimpleCAD API surface, including geometry operations, graph/model JSON workflows, expressions, QL, and export helpers.
 
 ## Import Surfaces
 
@@ -64,6 +64,11 @@ This index includes generated docs for the public SimpleCAD API surface, includi
 
 - [export_step](export_step.md) *(from operations.py)* `top-level`
 - [export_stl](export_stl.md) *(from operations.py)* `top-level`
+
+## FreeCAD Translation
+
+- [translate_model_json_to_fcstd](translate_model_json_to_fcstd.md) *(from freecad_translator.py)* `top-level`
+- [translate_model_json_to_freecad_script](translate_model_json_to_freecad_script.md) *(from freecad_translator.py)* `top-level`
 
 ## Modeling Graph and Replay
 

--- a/skills/simplecadapi/references/docs/api/translate_model_json_to_fcstd.md
+++ b/skills/simplecadapi/references/docs/api/translate_model_json_to_fcstd.md
@@ -1,0 +1,17 @@
+# translate_model_json_to_fcstd
+
+## API Definition
+
+```python
+def translate_model_json_to_fcstd(json_str: str, output_path: str, *, document_name: str = 'SimpleCADModel', freecad_cmd: Optional[str] = None) -> str
+```
+
+*Source: freecad_translator.py*
+
+## Import Surface
+
+- top-level: `from simplecadapi import translate_model_json_to_fcstd`
+
+## Description
+
+Translate canonical model JSON to `.FCStd` via FreeCADCmd/FreeCAD.

--- a/skills/simplecadapi/references/docs/api/translate_model_json_to_freecad_script.md
+++ b/skills/simplecadapi/references/docs/api/translate_model_json_to_freecad_script.md
@@ -1,0 +1,17 @@
+# translate_model_json_to_freecad_script
+
+## API Definition
+
+```python
+def translate_model_json_to_freecad_script(json_str: str, document_name: str = 'SimpleCADModel') -> str
+```
+
+*Source: freecad_translator.py*
+
+## Import Surface
+
+- top-level: `from simplecadapi import translate_model_json_to_freecad_script`
+
+## Description
+
+Translate exported model JSON into a FreeCAD Python script.

--- a/skills/simplecadapi/references/docs/core/README.md
+++ b/skills/simplecadapi/references/docs/core/README.md
@@ -2,7 +2,7 @@
 
 This directory documents the core public object model for SimpleCADAPI.
 
-SimpleCADAPI 2.x is OCP-native at runtime: public geometry objects are thin Python wrappers around OpenCascade/OCP shapes exposed through the `.wrapped` attribute. The package keeps the 1.x-style functional modeling API while adding graph recording, expression parameters, and replayable model JSON.
+SimpleCADAPI is OCP-native at runtime: public geometry objects are thin Python wrappers around OpenCascade/OCP shapes exposed through the `.wrapped` attribute. The package provides functional modeling operations, expression parameters, QL selectors, and replayable model JSON.
 
 ## Core Classes Overview
 
@@ -57,8 +57,9 @@ SimpleWorkplane  ← local modeling context
 - **Shape-first API**: users work with `Vertex`, `Edge`, `Wire`, `Face`, and `Solid`, not graph nodes.
 - **Functional modeling style**: public operations return new geometry values, e.g. `make_box_rsolid(...)`, `cut_rsolidlist(...)`, `fillet_rsolid(...)`.
 - **OCP-native runtime**: geometry construction, topology traversal, properties, booleans, transforms, and export use OCP/OpenCascade helpers.
-- **Replayable v2 workflows**: `GraphSession` can record a canonical low-level operation graph and `export_model_json()` can serialize it for `replay_model_json()`.
+- **Replayable graph workflows**: `GraphSession` can record a canonical low-level operation graph and `export_model_json()` can serialize it for `replay_model_json()`.
 - **Tags and metadata**: tags are useful for lightweight semantics; structured numeric facts should be stored in metadata such as `metadata["geo"]`.
+- **Indexed topology access**: use plural methods such as `get_edges()` and `get_faces()` for enumeration, and pass an index to the same getter, such as `get_edges(index)` or `get_faces(index)`, for intentional indexed picks that should become graph selection nodes.
 
 ## Basic Usage
 
@@ -98,6 +99,3 @@ print(len(rebuilt))
 - [User Guide](../../README.md)
 - [JSON Operation Graph Spec](operation_graph_json_spec.md)
 - [Serialization and Replay Operation Guides](serialization/)
-- [Declarative Constraint Layout Design Draft](declarative_constraints.md)
-- [SimpleCADAPI 2.0 Re-architecture Design](rearchitecture_2_0.md)
-- [SimpleCADAPI 2.0 Requirements and Acceptance](rearchitecture_2_0_requirements.md)

--- a/skills/simplecadapi/references/docs/core/operation_graph_json_spec.md
+++ b/skills/simplecadapi/references/docs/core/operation_graph_json_spec.md
@@ -116,7 +116,7 @@ source API 名字不等于 canonical graph op 名字。Composite source API 可�
 ```json
 {
   "schema_version": "2.0",
-  "producer_version": "2.0.0b2",
+  "producer_version": "2.0.0b3",
   "capabilities": {
     "selection_ref_strategies": true,
     "geo_select_nodes": true,
@@ -151,7 +151,7 @@ source API 名字不等于 canonical graph op 名字。Composite source API 可�
 | Field | Type | Meaning |
 | --- | --- | --- |
 | `selection_ref_strategies` | `bool` | detail feature 支持显式 topo refs / index / query 等多种选择策略 |
-| `geo_select_nodes` | `bool` | QL-derived detail selections can be serialized as `make_select_*` geo selector nodes |
+| `geo_select_nodes` | `bool` | detail selections from QL or indexed child-geometry getters can be serialized as `make_select_*` geo selector nodes |
 | `selector_hint_fallback` | `bool` | replay 时支持 selector hint 近似匹配回退 |
 | `display_payload` | `bool` | node 中包含 `display` 字段 |
 | `topology_delta_summary` | `bool` | 当前为 `false`，表示没有额外 summary-only delta schema |
@@ -267,7 +267,7 @@ source API 名字不等于 canonical graph op 名字。Composite source API 可�
 规则：
 
 - 如果某个参数没有表达式来源，则 `param_exprs` 中没有该键
-- 离散索引参数不会被表达式提升，例如：
+- 计数和 legacy fallback 索引参数不会被表达式提升，例如：
   - `selected_edge_indices`
   - `selected_face_indices`
   - `count`
@@ -425,7 +425,7 @@ detail feature 使用显式选择引用来稳定 replay。
     "geo_select_nodes",
     "selection_query",
     "explicit_topo_refs",
-    "stable_indices",
+    "legacy_indices",
     "selector_hint"
   ]
 }
@@ -468,7 +468,7 @@ detail feature 使用显式选择引用来稳定 replay。
 
 ### 8.4 Geo Select Nodes
 
-当 detail feature 使用 QL selector 时，新 graph 不把 QL 文本作为主要事实来源。运行时先解析 QL，读取每个被选中子形状的几何事实，并为每一项生成一个 canonical select 节点：
+当 detail feature 使用 QL selector 或 `get_edges(index)` / `get_faces(index)` 这类 indexed child-geometry getter 时，新 graph 不把 QL 文本或 Python list position 作为主要事实来源。运行时读取每个被选中子形状的几何事实，并为每一项生成一个 canonical select 节点：
 
 - `make_select_redge`
 - `make_select_rface`
@@ -476,7 +476,7 @@ detail feature 使用显式选择引用来稳定 replay。
 - `make_select_rvertex`
 - `make_select_rsolid`
 
-如果 QL 结果是 list，则每个元素对应一个独立 select 节点。feature node 通过 `selected_edge_node_ids` 或 `selected_face_node_ids` 指向这些节点。
+如果选择结果是 list，则每个元素对应一个独立 select 节点。feature node 通过 `selected_edge_node_ids` 或 `selected_face_node_ids` 指向这些节点。
 
 select node 示例：
 
@@ -488,7 +488,6 @@ select node 示例：
     "geo_selector": {
       "mode": "geo_exact",
       "kind": "edge",
-      "source_index": 1,
       "geom_type": "CIRCLE",
       "length": 6.283185307179586,
       "center": [0.0, 0.0, 0.0],
@@ -506,7 +505,7 @@ select node 示例：
 }
 ```
 
-`geo_selector` 不包含 tags，也不通过 tag 搜索。它固定到运行时选中对象的完整可见几何事实；`source_index` 用来保证在同一运行位置的 FreeCAD/OCP 子形状序列中直接命中绝对对应项，完整几何数据用于 fallback、审计和外部 adapter 校验。
+`geo_selector` 不包含 tags，也不通过 tag 搜索。它固定到运行时选中对象的完整可见几何事实；完整几何数据用于 replay、审计和外部 adapter 校验。
 
 ### 8.5 selection_query fallback
 
@@ -592,7 +591,7 @@ detail feature replay 的固定解析顺序为：
 1. `selected_edge_node_ids` / `selected_face_node_ids` 指向的 geo select nodes
 2. `selection_query` fallback
 3. `selected_edges` / `selected_faces` 中的显式 topo refs
-4. `selected_edge_indices` / `selected_face_indices`
+4. `selected_edge_indices` / `selected_face_indices` legacy fallback
 5. `selector_hint`
 
 适配器若要实现等价行为，必须保持这个顺序。
@@ -1272,8 +1271,8 @@ Notes:
 | `radius` | scalar | fillet radius |
 | `edge_count` | `int` | number of targeted edges |
 | `selected_edges` | `array<TopoRefWithHint>` | explicit edge refs |
-| `selected_edge_node_ids` | `array<string>` | primary geo select node refs for QL-derived selections |
-| `selected_edge_indices` | `array<int>` | stable index fallback against `solid.get_edges()` |
+| `selected_edge_node_ids` | `array<string>` | primary geo select node refs for QL/index-derived selections |
+| `selected_edge_indices` | `array<int>` | legacy index fallback when select nodes are unavailable |
 | `selection_query` | `ShapeSelector object` | legacy/fallback serialized QL selector |
 
 #### `make_chamfer_rsolid`
@@ -1287,8 +1286,8 @@ Notes:
 | `distance` | scalar | chamfer distance |
 | `edge_count` | `int` | number of targeted edges |
 | `selected_edges` | `array<TopoRefWithHint>` | explicit edge refs |
-| `selected_edge_node_ids` | `array<string>` | primary geo select node refs for QL-derived selections |
-| `selected_edge_indices` | `array<int>` | stable index fallback |
+| `selected_edge_node_ids` | `array<string>` | primary geo select node refs for QL/index-derived selections |
+| `selected_edge_indices` | `array<int>` | legacy index fallback when select nodes are unavailable |
 | `selection_query` | `ShapeSelector object` | legacy/fallback serialized QL selector |
 
 #### `make_shell_rsolid`
@@ -1302,8 +1301,8 @@ Notes:
 | `thickness` | scalar | shell thickness |
 | `removed_face_count` | `int` | number of faces removed |
 | `selected_faces` | `array<TopoRefWithHint>` | explicit face refs |
-| `selected_face_node_ids` | `array<string>` | primary geo select node refs for QL-derived selections |
-| `selected_face_indices` | `array<int>` | stable index fallback against `solid.get_faces()` |
+| `selected_face_node_ids` | `array<string>` | primary geo select node refs for QL/index-derived selections |
+| `selected_face_indices` | `array<int>` | legacy index fallback when select nodes are unavailable |
 | `selection_query` | `ShapeSelector object` | legacy/fallback serialized QL selector |
 
 ### 14.7 Pattern Ops
@@ -1409,7 +1408,7 @@ SDF / scalar field modeling is temporarily removed from the supported public sur
 1. 优先消费 `model.json`
 2. 若要做工业 interchange，请直接消费 canonical low-level `graph`
 3. 若要恢复参数化，请同时读取 `params`、`param_exprs`、`expression_graph`
-4. detail feature 必须按声明顺序解析选择：geo select nodes -> query fallback -> explicit refs -> indices -> hint
+4. detail feature 必须按声明顺序解析选择：geo select nodes -> query fallback -> explicit refs -> legacy indices -> hint
 5. 不要依赖 `display.summary` 解析业务语义
 
 ### 17.2 Tolerances For Consumers
@@ -1420,7 +1419,7 @@ SDF / scalar field modeling is temporarily removed from the supported public sur
 - `output_slot` 在深层 param 对象中可能是 `0.0`
 - `tags` 可能为空
 - `semantic_delta` / `topo_delta` 可能缺失
-- `selection_query` 是旧 payload / 手写 payload fallback；新 QL detail selections 应优先产生 geo select nodes
+- `selection_query` 是旧 payload / 手写 payload fallback；新 detail selections 应优先产生 geo select nodes
 
 ### 17.3 Recommended Minimal Interchange Subset
 
@@ -1435,7 +1434,7 @@ SDF / scalar field modeling is temporarily removed from the supported public sur
 
 - `selected_edge_node_ids` / `selected_face_node_ids` and their `make_select_*` nodes
 - `selected_edges` / `selected_faces`
-- `selected_edge_indices` / `selected_face_indices`
+- `selected_edge_indices` / `selected_face_indices` as legacy fallback
 - `selection_query` fallback, when present
 - `selector_hint`
 
@@ -1474,9 +1473,9 @@ SDF / scalar field modeling is temporarily removed from the supported public sur
         }
       }
     ],
-    "selected_edge_indices": [0, 1]
+    "selected_edge_node_ids": ["node_select_edge_0", "node_select_edge_1"]
   },
-  "inputs": ["node_f7e1ea08"],
+  "inputs": ["node_f7e1ea08", "node_select_edge_0", "node_select_edge_1"],
   "output_count": 1
 }
 ```

--- a/skills/simplecadapi/references/docs/core/serialization/README.md
+++ b/skills/simplecadapi/references/docs/core/serialization/README.md
@@ -1,6 +1,6 @@
 # Serialization and Replay Operation Guides
 
-This directory documents how SimpleCADAPI 2.x serializes replayable modeling operations into the canonical low-level `model.json` operation graph.
+This directory documents how SimpleCADAPI serializes replayable modeling operations into the canonical low-level `model.json` operation graph.
 
 The long-form schema reference remains [`../operation_graph_json_spec.md`](../operation_graph_json_spec.md). These files are more practical, operation-by-operation guides intended for people comparing source code with exported JSON.
 
@@ -51,7 +51,6 @@ Many user-facing functions are convenience APIs. During an active `GraphSession`
 
 - [Primitive and profile operations](primitives-and-profiles.md)
 - [Features, booleans, transforms, patterns, and selectors](features-booleans-transforms.md)
-- [Scalar field surfaces](scalar-fields.md)
 - [Expressions and replay behavior](expressions-and-replay.md)
 
 ## Example

--- a/skills/simplecadapi/references/docs/core/serialization/expressions-and-replay.md
+++ b/skills/simplecadapi/references/docs/core/serialization/expressions-and-replay.md
@@ -1,6 +1,6 @@
 # Expressions and Replay Behavior
 
-SimpleCADAPI 2.x stores expression-backed parameters in two places:
+SimpleCADAPI stores expression-backed parameters in two places:
 
 1. `node.params`: numeric / JSON-compatible snapshot used by simple replay
 2. `node.param_exprs`: references into the top-level `expression_graph`
@@ -127,7 +127,6 @@ If an example creates many independent showcase shapes, `leaf_ids` may contain m
 ## Unsupported / lossy expression cases
 
 - Python callables are not serialized as expressions.
-- Scalar-field Python callables are recorded as `opaque_callable` and cannot be replayed.
 - Some discrete selector data, topology refs, and counts are intentionally treated as JSON data rather than scalar expressions.
 
 ## Practical inspection snippet

--- a/skills/simplecadapi/references/docs/core/serialization/features-booleans-transforms.md
+++ b/skills/simplecadapi/references/docs/core/serialization/features-booleans-transforms.md
@@ -342,7 +342,6 @@ Serialized node:
         "selector_hint": {...}
       }
     ],
-    "selected_edge_indices": [0, 1, 2, 3],
     "selected_edge_node_ids": ["node_select_edge_0", "node_select_edge_1", "node_select_edge_2", "node_select_edge_3"]
   },
   "inputs": ["node_for_solid", "node_select_edge_0", "node_select_edge_1", "node_select_edge_2", "node_select_edge_3"],
@@ -350,14 +349,14 @@ Serialized node:
 }
 ```
 
-Each QL-selected edge is serialized as its own `make_select_redge` node whose `geo_selector` is fixed to the runtime-selected edge geometry. `geo_selector` does not contain tags; it uses geometry facts such as `source_index`, `geom_type`, `length`, `center`, endpoints, bbox, and `metadata_geo`.
+Each QL-selected or indexed getter-selected edge is serialized as its own `make_select_redge` node whose `geo_selector` is fixed to the runtime-selected edge geometry. `geo_selector` does not contain tags or source indices; it uses geometry facts such as `geom_type`, `length`, `center`, endpoints, bbox, and `metadata_geo`.
 
 Replay edge resolution order:
 
 1. Geo select nodes from `selected_edge_node_ids`
 2. Legacy/fallback `selection_query`, when present
 3. Explicit topo refs in `selected_edges`
-4. Stable indices in `selected_edge_indices`
+4. Legacy indices in `selected_edge_indices`, when select nodes are unavailable
 5. `selector_hint` fallback
 
 Then replay calls `fillet_rsolid(solid, resolved_edges, radius)`.
@@ -380,7 +379,6 @@ Serialized node shape is the same as fillet, except:
     "distance": 0.15,
     "edge_count": 4,
     "selected_edges": [...],
-    "selected_edge_indices": [...],
     "selected_edge_node_ids": [...]
   },
   "inputs": ["node_for_solid", "node_select_edge_0", "..."]
@@ -407,7 +405,6 @@ Serialized node:
     "thickness": 0.25,
     "removed_face_count": 1,
     "selected_faces": [...],
-    "selected_face_indices": [5],
     "selected_face_node_ids": ["node_select_face_0"]
   },
   "inputs": ["node_for_solid", "node_select_face_0"],
@@ -422,7 +419,7 @@ Replay face resolution order:
 1. Geo select nodes from `selected_face_node_ids`
 2. Legacy/fallback `selection_query`, when present
 3. Explicit topo refs in `selected_faces`
-4. Stable indices in `selected_face_indices`
+4. Legacy indices in `selected_face_indices`, when select nodes are unavailable
 5. `selector_hint` fallback
 
 Then replay calls `shell_rsolid(solid, resolved_faces, thickness)`.

--- a/skills/simplecadapi/references/docs/core/solid.md
+++ b/skills/simplecadapi/references/docs/core/solid.md
@@ -114,6 +114,23 @@ for i, face in enumerate(faces):
     print(f"面 {i}: 面积 {area:.3f}")
 ```
 
+### `get_faces(index)`
+
+Get one face by explicit index. In an active `GraphSession`, this intentional
+indexed pick is preserved as a graph geo select node.
+
+**Returns:**
+- `Face`: The selected face object
+
+**Example:**
+```python
+from simplecadapi import make_box_rsolid
+
+box = make_box_rsolid(width=4, height=3, depth=2)
+first_face = box.get_faces(0)
+print(first_face.get_area())
+```
+
 ### `get_edges()`
 
 Get all edges that make up the solid.
@@ -135,6 +152,23 @@ print(f"立方体有 {len(edges)} 条边")
 for i, edge in enumerate(edges):
     length = edge.get_length()
     print(f"边 {i}: 长度 {length:.3f}")
+```
+
+### `get_edges(index)`
+
+Get one edge by explicit index. In an active `GraphSession`, this intentional
+indexed pick is preserved as a graph geo select node.
+
+**Returns:**
+- `Edge`: The selected edge object
+
+**Example:**
+```python
+from simplecadapi import make_box_rsolid
+
+box = make_box_rsolid(width=4, height=3, depth=2)
+first_edge = box.get_edges(0)
+print(first_edge.get_length())
 ```
 
 ### `auto_tag_faces(geometry_type)`

--- a/skills/simplecadapi/references/docs/core/wire.md
+++ b/skills/simplecadapi/references/docs/core/wire.md
@@ -371,7 +371,7 @@ def create_wire_sequence():
         segments.append(segment)
     
     # 分析序列
-    total_path_length = sum(seg.get_edges()[0].get_length() for seg in segments)
+    total_path_length = sum(seg.get_edges(0).get_length() for seg in segments)
     
     print(f"路径段数: {len(segments)}")
     print(f"总路径长度: {total_path_length:.3f}")

--- a/src/simplecadapi/auto_tools/auto_docs_gen.py
+++ b/src/simplecadapi/auto_tools/auto_docs_gen.py
@@ -20,6 +20,7 @@ DEFAULT_SOURCE_FILENAMES: tuple[str, ...] = (
     "evolve.py",
     "ql.py",
     "serializer.py",
+    "freecad_translator.py",
     "expr.py",
     "graph.py",
     "sketch.py",
@@ -36,7 +37,7 @@ FULL_PUBLIC_FUNCTION_MODULES = frozenset(
 )
 
 EXPORTED_FUNCTION_MODULES = frozenset(
-    {"serializer.py", "graph.py", "expr.py", "errors.py"}
+    {"serializer.py", "freecad_translator.py", "graph.py", "expr.py", "errors.py"}
 )
 
 EXPORTED_CALLABLE_MODULES = frozenset(
@@ -413,6 +414,7 @@ class APIDocumentGenerator:
             "Tagging and Selection": [],
             "Boolean Operations": [],
             "Export": [],
+            "FreeCAD Translation": [],
             "Modeling Graph and Replay": [],
             "Expressions and Parameters": [],
             "Types and Errors": [],
@@ -430,6 +432,10 @@ class APIDocumentGenerator:
 
             if api.source_file in {"serializer.py", "graph.py"}:
                 categories["Modeling Graph and Replay"].append(api)
+                continue
+
+            if api.source_file == "freecad_translator.py":
+                categories["FreeCAD Translation"].append(api)
                 continue
 
             if api.source_file == "expr.py":
@@ -462,7 +468,7 @@ class APIDocumentGenerator:
         md_lines: List[str] = [
             "# SimpleCAD API Index",
             "",
-            "This index includes generated docs for the public SimpleCAD API surface, including v2 graph, expression, and model JSON workflows.",
+            "This index includes generated docs for the public SimpleCAD API surface, including geometry operations, graph/model JSON workflows, expressions, QL, and export helpers.",
             "",
             "## Import Surfaces",
             "",

--- a/src/simplecadapi/auto_tools/skill_pack.py
+++ b/src/simplecadapi/auto_tools/skill_pack.py
@@ -501,6 +501,7 @@ class SkillPackager:
             - Use `GraphSession` when the model should be replayable, inspectable, exported as model JSON, or translated to another CAD system.
             - Treat model JSON as the interchange boundary. Prefer `export_model_json(session)` and `replay_model_json(payload)` over hand-authored operation payloads.
             - Use QL for precise grounding. Query faces, edges, centers, normals, areas, lengths, curve types, and tags; print only the facts needed to validate the current step.
+            - Use `get_edges(index)`, `get_faces(index)`, `get_wires(index)`, or `get_vertices(index)` when an indexed topology pick is intentional; these picks are preserved as geo select nodes in replayable graph workflows.
             - Use tags for semantic intent and selection anchors, such as `role.mounting_surface`, `anchor.datum.primary`, `face.top`, or `group.fasteners`.
             - Keep numeric and geometric facts in metadata or graph payloads, not in tags.
             - When a QL-selected face or edge is used by a later feature, expect the graph/model workflow to preserve that selection as a stable geo select node.
@@ -658,6 +659,7 @@ class SkillPackager:
             - Use booleans and detail features after the base form is clear: cut openings, union intended merged bodies, then apply fillets, chamfers, or shell operations.
             - Use `GraphSession` whenever the result should be replayable, inspectable, serialized, or translated.
             - Use QL for grounding and selection. Query the facts you need, such as face normals, centers, areas, edge lengths, curve types, and tags.
+            - Use indexed child-geometry getters such as `get_edges(index)` and `get_faces(index)` when an indexed topology pick is intentional.
             - Use semantic tags for design intent and anchors. Keep numeric measurements and geometry facts in metadata or model JSON payloads.
             - Treat `export_model_json()` as the interchange boundary for replay and CAD translation.
             - Validate incrementally: after each major step, print small QL-derived facts such as selected face count, top face center, edge count, volume, or replay result count.
@@ -712,7 +714,8 @@ class SkillPackager:
 
             ## 5) Selection and tag discipline
 
-            - Prefer QL selectors over manual list indexing when selecting feature inputs.
+            - Prefer QL selectors for semantic/geometric feature input selection.
+            - Use `get_edges(index)`, `get_faces(index)`, `get_wires(index)`, or `get_vertices(index)` for intentional indexed picks in examples.
             - Attach semantic tags with `apply_tag(shape, tag)` and inspect with `list_tags(shape)`.
             - Use tags for intent, roles, anchors, groups, and topology names.
             - Store dimensions, positions, measured geometry, and descriptive payloads in metadata or model JSON, not in tags.

--- a/src/simplecadapi/core.py
+++ b/src/simplecadapi/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union, cast
 
 import numpy as np
 from OCP.TopAbs import TopAbs_EDGE, TopAbs_FACE, TopAbs_SOLID, TopAbs_VERTEX, TopAbs_WIRE
@@ -458,6 +458,37 @@ class TopoMixein:
         return list(self.parents)
 
 
+def _record_indexed_topology_selection(source: Any, selected_shapes: Iterable[Any]) -> None:
+    shapes = [shape for shape in selected_shapes if isinstance(shape, TaggedMixin)]
+    if not shapes:
+        return
+    try:
+        from .operations import _ensure_geo_selection_node_ids
+
+        _ensure_geo_selection_node_ids(cast(AnyShape, source), cast(List[AnyShape], shapes))
+    except Exception:
+        return
+
+
+class _TopologySelectionList(list):
+    def __init__(self, source: Any, target_kind: str, items: Iterable[Any]) -> None:
+        super().__init__(items)
+        self._source = source
+        self._target_kind = target_kind
+
+    def __getitem__(self, index: Any) -> Any:
+        selected = super().__getitem__(index)
+        if isinstance(index, slice):
+            _record_indexed_topology_selection(self._source, selected)
+            return selected
+        _record_indexed_topology_selection(self._source, [selected])
+        return selected
+
+
+def _selection_list(source: Any, target_kind: str, items: Iterable[Any]) -> List[Any]:
+    return cast(List[Any], _TopologySelectionList(source, target_kind, items))
+
+
 class Vertex(TaggedMixin, TopoMixein):
     """OCP-native vertex wrapper with tag support."""
 
@@ -551,6 +582,18 @@ class Edge(TaggedMixin, TopoMixein):
                     break
         return faces
 
+    def get_vertices(self, index: Optional[int] = None) -> Union[List[Vertex], Vertex]:
+        try:
+            vertices = [
+                child for child in self.get_children() if isinstance(child, Vertex)
+            ]
+            result = cast(List[Vertex], _selection_list(self, "vertex", vertices))
+            if index is None:
+                return result
+            return result[index]
+        except Exception as e:
+            raise ValueError(f"获取顶点失败: {e}")
+
     def __str__(self) -> str:
         return self._format_string(indent=0)
 
@@ -592,11 +635,14 @@ class Wire(TaggedMixin, TopoMixein):
         except Exception as e:
             raise ValueError(f"初始化线失败: {e}. 请检查输入的线对象是否有效。")
 
-    def get_edges(self) -> List[Edge]:
+    def get_edges(self, index: Optional[int] = None) -> Union[List[Edge], Edge]:
         try:
-            return cast(List[Edge], self.get_children())
+            result = cast(List[Edge], _selection_list(self, "edge", self.get_children()))
+            if index is None:
+                return result
+            return result[index]
         except Exception as e:
-            raise ValueError(f"获取边列表失败: {e}")
+            raise ValueError(f"获取边失败: {e}")
 
     def is_closed(self) -> bool:
         try:
@@ -695,21 +741,42 @@ class Face(TaggedMixin, TopoMixein):
         except Exception as e:
             raise ValueError(f"获取外边界线失败: {e}")
 
-    def get_inner_wires(self) -> List[Wire]:
+    def get_wires(self, index: Optional[int] = None) -> Union[List[Wire], Wire]:
         try:
-            return [w for w in cast(List[Wire], self.get_children()) if w.is_closed() and w._has_tag("wire.inner")]
+            wires = [child for child in self.get_children() if isinstance(child, Wire)]
+            result = cast(List[Wire], _selection_list(self, "wire", wires))
+            if index is None:
+                return result
+            return result[index]
+        except Exception as e:
+            raise ValueError(f"获取边界线失败: {e}")
+
+    def get_inner_wires(self, index: Optional[int] = None) -> Union[List[Wire], Wire]:
+        try:
+            wires = [
+                w
+                for w in cast(List[Wire], self.get_children())
+                if w.is_closed() and w._has_tag("wire.inner")
+            ]
+            result = cast(List[Wire], _selection_list(self, "wire", wires))
+            if index is None:
+                return result
+            return result[index]
         except Exception as e:
             raise ValueError(f"获取内边界线失败: {e}")
 
     def get_center(self) -> Vec3:
         return center_of_mass(self.wrapped)
 
-    def get_edges(self) -> List[Edge]:
+    def get_edges(self, index: Optional[int] = None) -> Union[List[Edge], Edge]:
         edges: List[Edge] = []
         edges.extend(self.get_outer_wire().get_edges())
         for inner in self.get_inner_wires():
             edges.extend(inner.get_edges())
-        return edges
+        result = cast(List[Edge], _selection_list(self, "edge", edges))
+        if index is None:
+            return result
+        return result[index]
 
     def get_adjacent_faces(self) -> List["Face"]:
         adjacent: Dict[str, Face] = {}
@@ -770,28 +837,40 @@ class Solid(TaggedMixin, TopoMixein):
         except Exception as e:
             raise ValueError(f"获取体积失败: {e}")
 
-    def get_faces(self) -> List[Face]:
+    def get_faces(self, index: Optional[int] = None) -> Union[List[Face], Face]:
         try:
-            return [f for f in cast(List[Face], self.get_children()) if isinstance(f, Face)]
+            faces = [
+                f for f in cast(List[Face], self.get_children()) if isinstance(f, Face)
+            ]
+            result = cast(List[Face], _selection_list(self, "face", faces))
+            if index is None:
+                return result
+            return result[index]
         except Exception as e:
-            raise ValueError(f"获取面列表失败: {e}")
+            raise ValueError(f"获取面失败: {e}")
 
-    def get_edges(self) -> List[Edge]:
+    def get_edges(self, index: Optional[int] = None) -> Union[List[Edge], Edge]:
         try:
             unique: Dict[str, Edge] = {}
             for face in self.get_faces():
                 for edge in face.get_edges():
                     unique.setdefault(edge.topo_id, edge)
-            return list(unique.values())
+            result = cast(List[Edge], _selection_list(self, "edge", unique.values()))
+            if index is None:
+                return result
+            return result[index]
         except Exception as e:
-            raise ValueError(f"获取边列表失败: {e}")
+            raise ValueError(f"获取边失败: {e}")
 
-    def get_edge_occurrences(self) -> List[Edge]:
+    def get_edge_occurrences(self, index: Optional[int] = None) -> Union[List[Edge], Edge]:
         try:
             edges: List[Edge] = []
             for face in self.get_faces():
                 edges.extend(face.get_edges())
-            return edges
+            result = cast(List[Edge], _selection_list(self, "edge", edges))
+            if index is None:
+                return result
+            return result[index]
         except Exception as e:
             raise ValueError(f"获取边实例列表失败: {e}")
 
@@ -803,7 +882,7 @@ class Solid(TaggedMixin, TopoMixein):
             elif geometry_type == "cylinder" and len(faces) == 3:
                 self._auto_tag_cylinder_faces(faces)
             elif geometry_type == "sphere" and len(faces) == 1:
-                self._tag_face(faces[0], "surface")
+                self._tag_face(next(iter(faces)), "surface")
             else:
                 for i, face in enumerate(faces):
                     self._tag_face(face, f"face_{i}")

--- a/src/simplecadapi/freecad_translator.py
+++ b/src/simplecadapi/freecad_translator.py
@@ -1099,8 +1099,6 @@ def _geo_selector_score(candidate, selector, candidate_index):
     elif kind == 'solid':
         if 'volume' in selector and hasattr(candidate, 'Volume'):
             score += abs(float(candidate.Volume) - float(selector['volume']))
-    if selector.get('source_index') is not None:
-        score += 0.0 if int(selector['source_index']) == int(candidate_index) else 1e-6
     return score
 
 
@@ -1109,10 +1107,6 @@ def _selection_index_for_selector(source_shape, selector):
     candidates = _subshape_candidates_for_kind(source_shape, kind)
     if not candidates:
         raise RuntimeError(f'No {kind} candidates available for geo selection')
-    if selector.get('source_index') is not None:
-        idx = int(selector['source_index'])
-        if 0 <= idx < len(candidates):
-            return idx
     ranked = sorted(
         enumerate(candidates),
         key=lambda item: _geo_selector_score(item[1], selector, item[0]),
@@ -1165,10 +1159,17 @@ def _register_geo_selection_node(*, node_id, op, params, inputs, tags, context, 
     return registered
 
 
-def _selected_indices_from_nodes(node_ids, fallback_indices):
+def _selected_indices_from_nodes(node_ids, fallback_indices, base_shape=None, kind=None):
     indices = []
     for node_id in node_ids or []:
         payload = GRAPH_SELECTIONS.get(str(node_id)) or GRAPH_NODES.get(str(node_id))
+        if isinstance(payload, dict) and base_shape is not None:
+            selector = dict(payload.get('selector') or payload.get('params', {}).get('geo_selector') or {})
+            if kind is not None:
+                selector['kind'] = str(kind)
+            if selector:
+                indices.append(_selection_index_for_selector(base_shape, selector))
+                continue
         if isinstance(payload, dict) and 'index' in payload:
             indices.append(int(payload['index']))
     if indices:
@@ -2442,7 +2443,7 @@ def _resolve_vec3_param(params, param_exprs, key):
             lines = [
                 f"{var_name} = doc.addObject('Part::Fillet', {_json_ascii(object_name)})",
                 f"{var_name}.Base = GRAPH_NODES[{_json_ascii(inputs[0])}]",
-                f"{var_name}.Edges = [(int(idx) + 1, float(_resolve_param_value({rp}, {re}, 'radius')), float(_resolve_param_value({rp}, {re}, 'radius'))) for idx in _selected_indices_from_nodes({rp}.get('selected_edge_node_ids', []), {rp}.get('selected_edge_indices', []))]",
+                f"{var_name}.Edges = [(int(idx) + 1, float(_resolve_param_value({rp}, {re}, 'radius')), float(_resolve_param_value({rp}, {re}, 'radius'))) for idx in _selected_indices_from_nodes({rp}.get('selected_edge_node_ids', []), {rp}.get('selected_edge_indices', []), _shape_from_graph_node({_json_ascii(inputs[0])}), 'edge')]",
             ]
             lines.append(f"_apply_detail_feature_bindings({var_name}, {re}, 'radius')")
             lines.extend(finish())
@@ -2452,7 +2453,7 @@ def _resolve_vec3_param(params, param_exprs, key):
             lines = [
                 f"{var_name} = doc.addObject('Part::Chamfer', {_json_ascii(object_name)})",
                 f"{var_name}.Base = GRAPH_NODES[{_json_ascii(inputs[0])}]",
-                f"{var_name}.Edges = [(int(idx) + 1, float(_resolve_param_value({rp}, {re}, 'distance')), float(_resolve_param_value({rp}, {re}, 'distance'))) for idx in _selected_indices_from_nodes({rp}.get('selected_edge_node_ids', []), {rp}.get('selected_edge_indices', []))]",
+                f"{var_name}.Edges = [(int(idx) + 1, float(_resolve_param_value({rp}, {re}, 'distance')), float(_resolve_param_value({rp}, {re}, 'distance'))) for idx in _selected_indices_from_nodes({rp}.get('selected_edge_node_ids', []), {rp}.get('selected_edge_indices', []), _shape_from_graph_node({_json_ascii(inputs[0])}), 'edge')]",
             ]
             lines.append(
                 f"_apply_detail_feature_bindings({var_name}, {re}, 'distance')"
@@ -2469,7 +2470,7 @@ def _resolve_vec3_param(params, param_exprs, key):
                 f"_apply_op_expression_bindings({var_name}, {_json_ascii(node.op)}, {re})"
             )
             if node.params.get("selected_face_indices") or node.params.get("selected_face_node_ids"):
-                face_name_expr = f"['Face' + str(int(i) + 1) for i in _selected_indices_from_nodes({rp}.get('selected_face_node_ids', []), {rp}.get('selected_face_indices', []))]"
+                face_name_expr = f"['Face' + str(int(i) + 1) for i in _selected_indices_from_nodes({rp}.get('selected_face_node_ids', []), {rp}.get('selected_face_indices', []), _shape_from_graph_node({_json_ascii(inputs[0])}), 'face')]"
                 lines.append(
                     f"{var_name}.Faces = (GRAPH_NODES[{_json_ascii(inputs[0])}], {face_name_expr})"
                 )

--- a/src/simplecadapi/operations.py
+++ b/src/simplecadapi/operations.py
@@ -616,10 +616,8 @@ def _make_geo_selector(
         "kind": kind,
         "metadata_geo": _jsonable_geo_value(shape.get_metadata("geo", {})),
     }
-    if source_shape is not None:
-        source_index = _source_selection_index(source_shape, shape, kind=kind)
-        if source_index is not None:
-            selector["source_index"] = source_index
+    # `source_shape` is intentionally not serialized as a source index. The
+    # canonical selector is geometry-based; source lineage comes from graph inputs.
 
     bbox_payload = _bbox_selector_payload(shape)
     if bbox_payload is not None:
@@ -704,6 +702,54 @@ def _record_geo_selection_nodes(
     return node_ids
 
 
+_GEO_SELECT_OPS = {
+    _OP_MAKE_SELECT_RVERTEX,
+    _OP_MAKE_SELECT_REDGE,
+    _OP_MAKE_SELECT_RWIRE,
+    _OP_MAKE_SELECT_RFACE,
+    _OP_MAKE_SELECT_RSOLID,
+}
+
+
+def _is_geo_select_node(node: object) -> bool:
+    return getattr(node, "op", None) in _GEO_SELECT_OPS
+
+
+def _ensure_source_shape_has_own_selection_node(source_shape: AnyShape) -> Optional[object]:
+    source_node = _active_graph_node_for_shape(source_shape)
+    if source_node is None or _is_geo_select_node(source_node):
+        return source_node
+
+    parent_source = _selection_source_for_shape(source_shape)
+    if parent_source is None:
+        return source_node
+
+    _ensure_geo_selection_node_ids(parent_source, [source_shape])
+    return _active_graph_node_for_shape(source_shape)
+
+
+def _ensure_geo_selection_node_ids(
+    source_shape: AnyShape,
+    selected_shapes: Sequence[AnyShape],
+) -> List[str]:
+    session = get_active_session()
+    if session is None:
+        return []
+    source_node = _ensure_source_shape_has_own_selection_node(source_shape)
+    if source_node is None:
+        return []
+
+    node_ids: List[str] = []
+    for selected in selected_shapes:
+        existing_node = _active_graph_node_for_shape(selected)
+        existing_op = getattr(existing_node, "op", None)
+        if existing_node is not None and existing_op in _GEO_SELECT_OPS:
+            node_ids.append(str(existing_node.node_id))
+            continue
+        node_ids.extend(_record_geo_selection_nodes(source_shape, [selected]))
+    return node_ids
+
+
 def _active_graph_node_for_shape(shape: AnyShape) -> Optional[object]:
     session = get_active_session()
     if session is None:
@@ -764,7 +810,7 @@ def _ensure_geo_selection_input_nodes(
             continue
         source = _selection_source_for_shape(shape)
         if source is not None:
-            _record_geo_selection_nodes(source, [shape])
+            _ensure_geo_selection_node_ids(source, [shape])
     return input_shapes
 
 
@@ -3976,29 +4022,24 @@ def fillet_rsolid(
         result._metadata = solid._metadata.copy()
 
         selected_edge_refs = _serialize_shape_refs(selected_edges)
-        selected_edge_indices = _serialize_selection_indices(
-            selected_edges, solid.get_edges()
-        )
-        selected_edge_node_ids = (
-            _record_geo_selection_nodes(solid, selected_edges)
-            if isinstance(edges, ShapeSelector)
-            else []
-        )
+        selected_edge_node_ids = _ensure_geo_selection_node_ids(solid, selected_edges)
+
+        selection_params: Dict[str, object] = {
+            "radius": radius,
+            "edge_count": len(selected_edges),
+            "selected_edges": selected_edge_refs,
+        }
+        if selected_edge_node_ids:
+            selection_params["selected_edge_node_ids"] = selected_edge_node_ids
+        else:
+            selection_params["selected_edge_indices"] = _serialize_selection_indices(
+                selected_edges, solid.get_edges()
+            )
 
         return _finalize_tracked_solid(
             result,
             op=_OP_MAKE_FILLET_RSOLID,
-            params={
-                "radius": radius,
-                "edge_count": len(selected_edges),
-                "selected_edges": selected_edge_refs,
-                "selected_edge_indices": selected_edge_indices,
-                **(
-                    {"selected_edge_node_ids": selected_edge_node_ids}
-                    if selected_edge_node_ids
-                    else {}
-                ),
-            },
+            params=selection_params,
             source_solid=solid,
             delta=tracked.delta,
             delta_entries=cast(Dict[str, Dict[str, object]], tracked.delta_entries),
@@ -4043,29 +4084,24 @@ def chamfer_rsolid(
         result._metadata = solid._metadata.copy()
 
         selected_edge_refs = _serialize_shape_refs(selected_edges)
-        selected_edge_indices = _serialize_selection_indices(
-            selected_edges, solid.get_edges()
-        )
-        selected_edge_node_ids = (
-            _record_geo_selection_nodes(solid, selected_edges)
-            if isinstance(edges, ShapeSelector)
-            else []
-        )
+        selected_edge_node_ids = _ensure_geo_selection_node_ids(solid, selected_edges)
+
+        selection_params: Dict[str, object] = {
+            "distance": distance,
+            "edge_count": len(selected_edges),
+            "selected_edges": selected_edge_refs,
+        }
+        if selected_edge_node_ids:
+            selection_params["selected_edge_node_ids"] = selected_edge_node_ids
+        else:
+            selection_params["selected_edge_indices"] = _serialize_selection_indices(
+                selected_edges, solid.get_edges()
+            )
 
         return _finalize_tracked_solid(
             result,
             op=_OP_MAKE_CHAMFER_RSOLID,
-            params={
-                "distance": distance,
-                "edge_count": len(selected_edges),
-                "selected_edges": selected_edge_refs,
-                "selected_edge_indices": selected_edge_indices,
-                **(
-                    {"selected_edge_node_ids": selected_edge_node_ids}
-                    if selected_edge_node_ids
-                    else {}
-                ),
-            },
+            params=selection_params,
             source_solid=solid,
             delta=tracked.delta,
             delta_entries=cast(Dict[str, Dict[str, object]], tracked.delta_entries),
@@ -4115,29 +4151,24 @@ def shell_rsolid(
         result._metadata = solid._metadata.copy()
 
         selected_face_refs = _serialize_shape_refs(selected_faces)
-        selected_face_indices = _serialize_selection_indices(
-            selected_faces, solid.get_faces()
-        )
-        selected_face_node_ids = (
-            _record_geo_selection_nodes(solid, selected_faces)
-            if isinstance(faces_to_remove, ShapeSelector)
-            else []
-        )
+        selected_face_node_ids = _ensure_geo_selection_node_ids(solid, selected_faces)
+
+        selection_params: Dict[str, object] = {
+            "thickness": thickness,
+            "removed_face_count": len(selected_faces),
+            "selected_faces": selected_face_refs,
+        }
+        if selected_face_node_ids:
+            selection_params["selected_face_node_ids"] = selected_face_node_ids
+        else:
+            selection_params["selected_face_indices"] = _serialize_selection_indices(
+                selected_faces, solid.get_faces()
+            )
 
         return _finalize_tracked_solid(
             result,
             op=_OP_MAKE_SHELL_RSOLID,
-            params={
-                "thickness": thickness,
-                "removed_face_count": len(selected_faces),
-                "selected_faces": selected_face_refs,
-                "selected_face_indices": selected_face_indices,
-                **(
-                    {"selected_face_node_ids": selected_face_node_ids}
-                    if selected_face_node_ids
-                    else {}
-                ),
-            },
+            params=selection_params,
             source_solid=solid,
             delta=tracked.delta,
             delta_entries=cast(Dict[str, Dict[str, object]], tracked.delta_entries),

--- a/src/simplecadapi/serializer.py
+++ b/src/simplecadapi/serializer.py
@@ -934,9 +934,6 @@ def _geo_selector_score(
         if "volume" in selector:
             score += abs(float(shape.get_volume()) - float(selector["volume"]))
 
-    source_index = selector.get("source_index")
-    if source_index is not None and candidate_index is not None:
-        score += 0.0 if int(source_index) == int(candidate_index) else 1e-6
     return score
 
 
@@ -945,12 +942,6 @@ def _resolve_shape_from_geo_selector(source: AnyShape, selector: Dict[str, Any])
     candidates = _candidate_shapes_for_geo_selection(source, kind)
     if not candidates:
         raise ValueError(f"geo selector found no {kind} candidates in source")
-
-    source_index = selector.get("source_index")
-    if source_index is not None:
-        index = int(source_index)
-        if 0 <= index < len(candidates):
-            return candidates[index]
 
     ranked = sorted(
         enumerate(candidates),

--- a/test/test_freecad_translator.py
+++ b/test/test_freecad_translator.py
@@ -219,7 +219,7 @@ with open(OUT_PATH, 'w', encoding='utf-8') as fh:
         radius = scad.var("fillet_r", 0.25)
         with GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            scad.fillet_rsolid(box, box.get_edges()[:2], radius)
+            scad.fillet_rsolid(box, [box.get_edges(i) for i in range(2)], radius)
 
         script = scad.translate_model_json_to_freecad_script(
             scad.export_model_json(session)
@@ -658,7 +658,7 @@ with open(OUT_PATH, 'w', encoding='utf-8') as fh:
             scad.revolve_rsolid(rev_face, axis=(0.0, 0.0, 1.0), angle=180.0)
             scad.sweep_rsolid(face, helix, is_frenet=True)
             box = scad.make_box_rsolid(2.0, 2.0, 2.0)
-            scad.shell_rsolid(box, box.get_faces()[:1], 0.25)
+            scad.shell_rsolid(box, [box.get_faces(0)], 0.25)
 
         payload = scad.export_model_json(session)
         payload_obj = self._expression_payload(payload)
@@ -753,8 +753,8 @@ with open(OUT_PATH, 'w', encoding='utf-8') as fh:
             scad.mirror_shape(
                 box, plane_origin=(0.0, 0.0, 0.0), plane_normal=(0.0, 0.0, 1.0)
             )
-            scad.fillet_rsolid(box, box.get_edges()[:1], 0.2)
-            scad.chamfer_rsolid(box, box.get_edges()[:1], 0.3)
+            scad.fillet_rsolid(box, [box.get_edges(0)], 0.2)
+            scad.chamfer_rsolid(box, [box.get_edges(0)], 0.3)
 
         payload_obj = self._expression_payload(scad.export_model_json(session))
         payload_obj["expression_graph"]["nodes"] = [
@@ -1751,8 +1751,8 @@ with open(OUT_PATH, 'w', encoding='utf-8') as fh:
     ):
         with GraphSession() as session:
             box = scad.make_box_rsolid(2.0, 2.0, 2.0)
-            scad.chamfer_rsolid(box, box.get_edges()[:1], 0.2)
-            scad.shell_rsolid(box, box.get_faces()[:1], 0.1)
+            scad.chamfer_rsolid(box, [box.get_edges(0)], 0.2)
+            scad.shell_rsolid(box, [box.get_faces(0)], 0.1)
 
         script = scad.translate_model_json_to_freecad_script(
             scad.export_model_json(session)

--- a/test/test_model_json.py
+++ b/test/test_model_json.py
@@ -311,7 +311,7 @@ class TestModelJson(unittest.TestCase):
     def test_graph_preserves_explicit_selected_refs_for_detail_features(self):
         with GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            scad.fillet_rsolid(box, box.get_edges()[:2], 0.3)
+            scad.fillet_rsolid(box, [box.get_edges(i) for i in range(2)], 0.3)
 
         payload = json.loads(scad.export_model_json(session))
         fillet_nodes = [
@@ -386,7 +386,7 @@ class TestModelJson(unittest.TestCase):
     def test_graph_selection_refs_follow_declared_schema(self):
         with GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            scad.fillet_rsolid(box, box.get_edges()[:2], 0.3)
+            scad.fillet_rsolid(box, [box.get_edges(i) for i in range(2)], 0.3)
 
         payload = json.loads(scad.export_model_json(session))
         contract = payload["canonical_contract"]

--- a/test/test_original_api_integration.py
+++ b/test/test_original_api_integration.py
@@ -91,7 +91,7 @@ class TestOriginalFeatureApiIntegration(unittest.TestCase):
 
     def test_fillet_rsolid_auto_applies_semantic_tags(self):
         box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-        edges = box.get_edges()[:4]
+        edges = [box.get_edges(i) for i in range(4)]
         filleted = scad.fillet_rsolid(box, edges, 0.2)
 
         self.assertEqual(filleted.get_metadata("track")["op"], "make_fillet_rsolid")
@@ -101,7 +101,7 @@ class TestOriginalFeatureApiIntegration(unittest.TestCase):
 
     def test_shell_rsolid_auto_applies_track_metadata(self):
         box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-        faces_to_remove = [box.get_faces()[0]]
+        faces_to_remove = [box.get_faces(0)]
         shelled = scad.shell_rsolid(box, faces_to_remove, 0.2)
 
         self.assertEqual(shelled.get_metadata("track")["op"], "make_shell_rsolid")
@@ -187,8 +187,8 @@ class TestOriginalApiGraphRecording(unittest.TestCase):
         with GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
 
-        face_ref = box.get_faces()[0].get_metadata("topo_ref")
-        edge_ref = box.get_edges()[0].get_metadata("topo_ref")
+        face_ref = box.get_faces(0).get_metadata("topo_ref")
+        edge_ref = box.get_edges(0).get_metadata("topo_ref")
 
         self.assertIsInstance(face_ref, dict)
         self.assertEqual(face_ref["kind"], "FACE")

--- a/test/test_rearchitecture_2_0_contract.py
+++ b/test/test_rearchitecture_2_0_contract.py
@@ -281,7 +281,7 @@ class TestRearchitecture20IoContracts(unittest.TestCase):
     def test_model_json_declares_selection_ref_resolution_order(self):
         with GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            scad.fillet_rsolid(box, box.get_edges()[:2], 0.2)
+            scad.fillet_rsolid(box, [box.get_edges(i) for i in range(2)], 0.2)
 
         payload = scad.import_model_json(scad.export_model_json(session))
         selection_schema = payload["canonical_contract"]["selection_ref_schema"]

--- a/test/test_rearchitecture_2_0_ops.py
+++ b/test/test_rearchitecture_2_0_ops.py
@@ -131,7 +131,7 @@ class TestRearchitecture20CoreOps(unittest.TestCase):
         radius = scad.var("fillet_r", 0.2)
         with GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            result = scad.fillet_rsolid(box, box.get_edges()[:4], radius)
+            result = scad.fillet_rsolid(box, [box.get_edges(i) for i in range(4)], radius)
 
         self.assertIsInstance(result, scad.Solid)
         leaf = session.graph.leaf_nodes()[0]
@@ -142,7 +142,7 @@ class TestRearchitecture20CoreOps(unittest.TestCase):
         distance = scad.var("chamfer_d", 0.2)
         with GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            result = scad.chamfer_rsolid(box, box.get_edges()[:4], distance)
+            result = scad.chamfer_rsolid(box, [box.get_edges(i) for i in range(4)], distance)
 
         self.assertIsInstance(result, scad.Solid)
         leaf = session.graph.leaf_nodes()[0]
@@ -153,7 +153,7 @@ class TestRearchitecture20CoreOps(unittest.TestCase):
         thickness = scad.var("shell_t", 0.2)
         with GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            result = scad.shell_rsolid(box, [box.get_faces()[0]], thickness)
+            result = scad.shell_rsolid(box, [box.get_faces(0)], thickness)
 
         self.assertIsInstance(result, scad.Solid)
         leaf = session.graph.leaf_nodes()[0]
@@ -163,7 +163,7 @@ class TestRearchitecture20CoreOps(unittest.TestCase):
     def test_shell_produces_topology_delta_at_runtime(self):
         with GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            result = scad.shell_rsolid(box, [box.get_faces()[0]], 0.2)
+            result = scad.shell_rsolid(box, [box.get_faces(0)], 0.2)
 
         self.assertIsInstance(result, scad.Solid)
         leaf = session.graph.leaf_nodes()[0]
@@ -179,7 +179,7 @@ class TestRearchitecture20CoreOps(unittest.TestCase):
     def test_shell_topology_delta_survives_graph_json_roundtrip(self):
         with GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            scad.shell_rsolid(box, [box.get_faces()[0]], 0.2)
+            scad.shell_rsolid(box, [box.get_faces(0)], 0.2)
 
         restored = scad.import_graph_json(scad.export_graph_json(session.graph))
         leaf = restored.leaf_nodes()[0]

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -117,7 +117,7 @@ class TestExportImport(unittest.TestCase):
     def test_export_graph_json_display_payload_includes_selection_counts(self):
         with scad.GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            edges = box.get_edges()[:4]
+            edges = [box.get_edges(i) for i in range(4)]
             scad.fillet_rsolid(box, edges, 0.2)
 
         payload = json.loads(export_graph_json(session.graph))
@@ -351,7 +351,7 @@ class TestReplay(unittest.TestCase):
     def test_replay_fillet_roundtrip_with_selected_edges(self):
         with scad.GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            edges = box.get_edges()[:4]
+            edges = [box.get_edges(i) for i in range(4)]
             filleted = scad.fillet_rsolid(box, edges, 0.2)
 
         graph_json = export_graph_json(session.graph)
@@ -362,10 +362,58 @@ class TestReplay(unittest.TestCase):
         self.assertIsInstance(results[0], scad.Solid)
         self.assertAlmostEqual(results[0].get_volume(), filleted.get_volume(), places=5)
 
+    def test_indexed_edge_access_records_geo_select_nodes(self):
+        with scad.GraphSession() as session:
+            box = scad.make_box_rsolid(4.0, 4.0, 4.0)
+            edge = box.get_edges(0)
+            filleted = scad.fillet_rsolid(box, [edge], 0.2)
+
+        payload = json.loads(export_graph_json(session.graph))
+        fillet_node = next(
+            node for node in payload["nodes"] if node["op"] == "make_fillet_rsolid"
+        )
+        selection_node_ids = fillet_node["params"]["selected_edge_node_ids"]
+        self.assertEqual(len(selection_node_ids), 1)
+        selection_node = next(
+            node for node in payload["nodes"] if node["node_id"] == selection_node_ids[0]
+        )
+        self.assertEqual(selection_node["op"], "make_select_redge")
+        self.assertNotIn("source_index", selection_node["params"]["geo_selector"])
+        self.assertNotIn("selected_edge_indices", fillet_node["params"])
+
+        results = replay_graph(import_graph_json(json.dumps(payload)))
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], scad.Solid)
+        self.assertAlmostEqual(results[0].get_volume(), filleted.get_volume(), places=5)
+
+    def test_indexed_edge_getter_records_multiple_geo_select_nodes(self):
+        with scad.GraphSession() as session:
+            box = scad.make_box_rsolid(4.0, 4.0, 4.0)
+            edges = [box.get_edges(i) for i in range(2)]
+            filleted = scad.fillet_rsolid(box, edges, 0.2)
+
+        payload = json.loads(export_graph_json(session.graph))
+        fillet_node = next(
+            node for node in payload["nodes"] if node["op"] == "make_fillet_rsolid"
+        )
+        selection_node_ids = fillet_node["params"]["selected_edge_node_ids"]
+        self.assertEqual(len(selection_node_ids), 2)
+        selection_nodes = [
+            node for node in payload["nodes"] if node["node_id"] in selection_node_ids
+        ]
+        self.assertTrue(
+            all(node["op"] == "make_select_redge" for node in selection_nodes)
+        )
+
+        results = replay_graph(import_graph_json(json.dumps(payload)))
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], scad.Solid)
+        self.assertAlmostEqual(results[0].get_volume(), filleted.get_volume(), places=5)
+
     def test_replay_chamfer_roundtrip_with_selected_edges(self):
         with scad.GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            edges = box.get_edges()[:4]
+            edges = [box.get_edges(i) for i in range(4)]
             chamfered = scad.chamfer_rsolid(box, edges, 0.2)
 
         graph_json = export_graph_json(session.graph)
@@ -381,7 +429,7 @@ class TestReplay(unittest.TestCase):
     def test_replay_shell_roundtrip_with_selected_faces(self):
         with scad.GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            shelled = scad.shell_rsolid(box, [box.get_faces()[0]], 0.2)
+            shelled = scad.shell_rsolid(box, [box.get_faces(0)], 0.2)
 
         graph_json = export_graph_json(session.graph)
         restored = import_graph_json(graph_json)
@@ -391,10 +439,83 @@ class TestReplay(unittest.TestCase):
         self.assertIsInstance(results[0], scad.Solid)
         self.assertAlmostEqual(results[0].get_volume(), shelled.get_volume(), places=5)
 
+    def test_indexed_face_access_records_geo_select_nodes(self):
+        with scad.GraphSession() as session:
+            box = scad.make_box_rsolid(4.0, 4.0, 4.0)
+            face = box.get_faces(0)
+            shelled = scad.shell_rsolid(box, [face], 0.2)
+
+        payload = json.loads(export_graph_json(session.graph))
+        shell_node = next(
+            node for node in payload["nodes"] if node["op"] == "make_shell_rsolid"
+        )
+        selection_node_ids = shell_node["params"]["selected_face_node_ids"]
+        self.assertEqual(len(selection_node_ids), 1)
+        selection_node = next(
+            node for node in payload["nodes"] if node["node_id"] == selection_node_ids[0]
+        )
+        self.assertEqual(selection_node["op"], "make_select_rface")
+        self.assertNotIn("source_index", selection_node["params"]["geo_selector"])
+        self.assertNotIn("selected_face_indices", shell_node["params"])
+
+        results = replay_graph(import_graph_json(json.dumps(payload)))
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], scad.Solid)
+        self.assertAlmostEqual(results[0].get_volume(), shelled.get_volume(), places=5)
+
+    def test_nested_indexed_edge_access_records_source_face_select_node(self):
+        with scad.GraphSession() as session:
+            box = scad.make_box_rsolid(4.0, 4.0, 4.0)
+            face = box.get_faces(0)
+            edge = face.get_edges(0)
+            filleted = scad.fillet_rsolid(box, [edge], 0.2)
+
+        payload = json.loads(export_graph_json(session.graph))
+        select_face_nodes = [
+            node for node in payload["nodes"] if node["op"] == "make_select_rface"
+        ]
+        self.assertEqual(len(select_face_nodes), 1)
+
+        fillet_node = next(
+            node for node in payload["nodes"] if node["op"] == "make_fillet_rsolid"
+        )
+        selection_node_id = fillet_node["params"]["selected_edge_node_ids"][0]
+        selection_node = next(
+            node for node in payload["nodes"] if node["node_id"] == selection_node_id
+        )
+        self.assertEqual(selection_node["op"], "make_select_redge")
+        self.assertEqual(selection_node["inputs"], [select_face_nodes[0]["node_id"]])
+        self.assertNotIn("source_index", selection_node["params"]["geo_selector"])
+
+        results = replay_graph(import_graph_json(json.dumps(payload)))
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], scad.Solid)
+        self.assertAlmostEqual(results[0].get_volume(), filleted.get_volume(), places=5)
+
+    def test_indexed_child_geometry_getters_record_select_nodes(self):
+        with scad.GraphSession() as session:
+            box = scad.make_box_rsolid(4.0, 4.0, 4.0)
+            face = box.get_faces(0)
+            wire = face.get_wires(0)
+            edge = wire.get_edges(0)
+            vertex = edge.get_vertices(0)
+
+        payload = json.loads(export_graph_json(session.graph))
+        ops = [node["op"] for node in payload["nodes"]]
+
+        self.assertIsInstance(face, scad.Face)
+        self.assertIsInstance(wire, scad.Wire)
+        self.assertIsInstance(edge, scad.Edge)
+        self.assertIsInstance(vertex, scad.Vertex)
+        self.assertIn("make_select_rface", ops)
+        self.assertIn("make_select_rwire", ops)
+        self.assertIn("make_select_redge", ops)
+        self.assertIn("make_select_rvertex", ops)
+
     def test_replay_fillet_roundtrip_with_selector_hint_fallback(self):
         with scad.GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            edges = box.get_edges()[:4]
+            edges = [box.get_edges(i) for i in range(4)]
             filleted = scad.fillet_rsolid(box, edges, 0.2)
 
         payload = json.loads(export_graph_json(session.graph))
@@ -410,6 +531,7 @@ class TestReplay(unittest.TestCase):
         )
         for ref in damaged_fillet["params"]["selected_edges"]:
             ref["topo_id"] = "missing_edge_ref"
+        damaged_fillet["params"]["selected_edge_node_ids"] = []
         damaged_fillet["params"]["selected_edge_indices"] = []
 
         restored = import_graph_json(json.dumps(damaged))
@@ -422,7 +544,7 @@ class TestReplay(unittest.TestCase):
     def test_replay_shell_roundtrip_with_selector_hint_fallback(self):
         with scad.GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            shelled = scad.shell_rsolid(box, [box.get_faces()[0]], 0.2)
+            shelled = scad.shell_rsolid(box, [box.get_faces(0)], 0.2)
 
         payload = json.loads(export_graph_json(session.graph))
         shell_node = next(
@@ -437,6 +559,7 @@ class TestReplay(unittest.TestCase):
         )
         for ref in damaged_shell["params"]["selected_faces"]:
             ref["topo_id"] = "missing_face_ref"
+        damaged_shell["params"]["selected_face_node_ids"] = []
         damaged_shell["params"]["selected_face_indices"] = []
 
         restored = import_graph_json(json.dumps(damaged))
@@ -483,7 +606,7 @@ class TestReplay(unittest.TestCase):
     def test_ql_tag_filter_records_geo_select_node_not_tag_selector(self):
         with scad.GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            scad.apply_tag(box.get_edges()[0], "role.target_edge")
+            scad.apply_tag(box.get_edges(0), "role.target_edge")
             selector = scad.ql.edges().where(scad.ql.tag("role.target_edge")).exactly(1)
             filleted = scad.fillet_rsolid(box, selector, 0.2)
 
@@ -499,8 +622,7 @@ class TestReplay(unittest.TestCase):
 
         self.assertNotIn("selection_query", fillet_node["params"])
         self.assertNotIn("tags", select_node["params"]["geo_selector"])
-        self.assertIn("source_index", select_node["params"]["geo_selector"])
-        self.assertIsInstance(select_node["params"]["geo_selector"]["source_index"], int)
+        self.assertNotIn("source_index", select_node["params"]["geo_selector"])
 
         fillet_node["params"]["selected_edges"] = []
         fillet_node["params"]["selected_edge_indices"] = []
@@ -606,7 +728,7 @@ class TestReplay(unittest.TestCase):
         select_node = select_nodes[0]
         self.assertEqual(select_node["params"]["target_kind"], "face")
         self.assertEqual(select_node["params"]["geo_selector"]["kind"], "face")
-        self.assertIn("source_index", select_node["params"]["geo_selector"])
+        self.assertNotIn("source_index", select_node["params"]["geo_selector"])
         self.assertNotIn("tags", select_node["params"]["geo_selector"])
 
         sweep_node = next(
@@ -764,12 +886,15 @@ class TestReplay(unittest.TestCase):
     def test_replay_selection_cardinality_mismatch_raises_by_default(self):
         with scad.GraphSession() as session:
             box = scad.make_box_rsolid(4.0, 4.0, 4.0)
-            scad.fillet_rsolid(box, box.get_edges()[:1], 0.2)
+            scad.fillet_rsolid(box, [box.get_edges(0)], 0.2)
 
         payload = json.loads(scad.export_model_json(session))
         fillet_node = next(
             node for node in payload["graph"]["nodes"] if node["op"] == "make_fillet_rsolid"
         )
+        fillet_node["params"]["selected_edge_node_ids"] = []
+        fillet_node["params"]["selected_edges"] = []
+        fillet_node["params"]["selected_edge_indices"] = []
         fillet_node["params"]["selection_query"] = scad.ql.edges().take(2).exactly(2).to_dict()
         fillet_node["params"]["edge_count"] = 1
 

--- a/test/test_tracking_features.py
+++ b/test/test_tracking_features.py
@@ -106,7 +106,7 @@ class TestTrackedFillet(unittest.TestCase):
     def setUp(self):
         self.box = scad.make_box_rsolid(10, 10, 10)
         # Select some edges for filleting
-        self.edges = self.box.get_edges()[:4]
+        self.edges = [self.box.get_edges(i) for i in range(4)]
 
     def test_fillet_returns_tracked_result(self):
         result = tracked_fillet(self.box, self.edges, 0.5)
@@ -128,7 +128,7 @@ class TestTrackedFillet(unittest.TestCase):
 class TestTrackedChamfer(unittest.TestCase):
     def setUp(self):
         self.box = scad.make_box_rsolid(10, 10, 10)
-        self.edges = self.box.get_edges()[:4]
+        self.edges = [self.box.get_edges(i) for i in range(4)]
 
     def test_chamfer_returns_tracked_result(self):
         result = tracked_chamfer(self.box, self.edges, 0.5)

--- a/tests/test_ocp_core_no_cadquery.py
+++ b/tests/test_ocp_core_no_cadquery.py
@@ -8,8 +8,8 @@ from simplecadapi.core import Edge, Face, Solid, Vertex, Wire
 
 def test_core_public_shapes_do_not_expose_cq_accessors():
     box = make_box_rsolid(1, 2, 3)
-    face = box.get_faces()[0]
-    edge = face.get_outer_wire().get_edges()[0]
+    face = box.get_faces(0)
+    edge = face.get_outer_wire().get_edges(0)
     vertex = edge.get_start_vertex()
     wire = face.get_outer_wire()
 

--- a/tests/test_topology_identity.py
+++ b/tests/test_topology_identity.py
@@ -48,13 +48,13 @@ def test_solid_get_edges_returns_unique_topological_edges():
 def test_edge_incident_faces_and_face_adjacency_are_available():
     box, _ = _box_edge_occurrences()
 
-    edge = box.get_edges()[0]
+    edge = box.get_edges(0)
     incident_faces = edge.get_incident_faces()
 
     assert len(incident_faces) == 2
     assert len({face.topo_id for face in incident_faces}) == 2
 
-    face = box.get_faces()[0]
+    face = box.get_faces(0)
     adjacent_faces = face.get_adjacent_faces()
 
     assert len(adjacent_faces) == 4

--- a/uv.lock
+++ b/uv.lock
@@ -2606,7 +2606,7 @@ wheels = [
 
 [[package]]
 name = "simplecadapi"
-version = "2.0.0b2"
+version = "2.0.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "cadquery-ocp" },


### PR DESCRIPTION
## Summary
- add plural indexed topology getters that record canonical make_select_* nodes
- remove source_index dependency from selection replay and FreeCAD translation
- refresh README, docs, generated API docs, skill references, and bump package version to 2.0.0b3

## Verification
- uv run python -m pytest test tests
- python3 -m compileall src/simplecadapi
- git diff --check
- uv build --out-dir /var/folders/k4/9dkl_8j94kjcwlc8lgvzyx9r0000gn/T/opencode/simplecadapi-2.0.0b3-dist
- uv run python -m twine check /var/folders/k4/9dkl_8j94kjcwlc8lgvzyx9r0000gn/T/opencode/simplecadapi-2.0.0b3-dist/*